### PR TITLE
Add compatibility conversions for mobwrite

### DIFF
--- a/blue-common/src/main/scala/gnieh/blue/common/CouchConfiguration.scala
+++ b/blue-common/src/main/scala/gnieh/blue/common/CouchConfiguration.scala
@@ -41,12 +41,12 @@ class CouchConfiguration(val config: Config) {
   val couchDesigns = new File(config.getString("couch.design.dir"))
 
   def adminSession = {
-    val sess = couch.startSession
+    val sess = couch.startCookieSession
     sess.login(couchAdminName, couchAdminPassword)
     sess
   }
 
-  def asAdmin[T](code: CouchSession => T) = {
+  def asAdmin[T](code: CookieSession => T) = {
     val sess = adminSession
     try {
       code(sess)

--- a/blue-common/src/main/scala/gnieh/blue/common/Hook.scala
+++ b/blue-common/src/main/scala/gnieh/blue/common/Hook.scala
@@ -16,21 +16,21 @@
 package gnieh.blue
 package common
 
-import gnieh.sohva.control.CouchSession
+import gnieh.sohva.control.CookieSession
 
 trait PaperCreated {
-  def afterCreate(paperId: String, session: CouchSession): Unit
+  def afterCreate(paperId: String, session: CookieSession): Unit
 }
 
 trait PaperDeleted {
-  def afterDelete(paperId: String, session: CouchSession): Unit
+  def afterDelete(paperId: String, session: CookieSession): Unit
 }
 
 trait UserRegistered {
-  def afterRegister(username: String, session: CouchSession): Unit
+  def afterRegister(username: String, session: CookieSession): Unit
 }
 
 trait UserUnregistered {
-  def afterUnregister(username: String, session: CouchSession): Unit
+  def afterUnregister(username: String, session: CookieSession): Unit
 }
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/SettingsHooks.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/SettingsHooks.scala
@@ -19,7 +19,7 @@ package impl
 
 import common._
 
-import gnieh.sohva.control.CouchSession
+import gnieh.sohva.control.CookieSession
 
 import org.osgi.service.log.LogService
 
@@ -41,7 +41,7 @@ class CreateSettingsHook(config: Config, logger: Logger) extends PaperCreated {
       config.getSeconds("compiler.interval")
     )
 
-  def afterCreate(paperId: String, session: CouchSession): Unit = {
+  def afterCreate(paperId: String, session: CookieSession): Unit = {
     // after creation of a paper, save default settings
     val db = session.database(couchConfig.database("blue_papers"))
     db.saveDoc(defaultSettings(paperId)) recover {
@@ -60,7 +60,7 @@ class DeleteSettingsHook(config: Config, logger: Logger) extends PaperDeleted {
 
   val couchConfig = new CouchConfiguration(config)
 
-  def afterDelete(paperId: String, session: CouchSession): Unit = {
+  def afterDelete(paperId: String, session: CookieSession): Unit = {
     // after creation of a paper, save default settings
     val db = session.database(couchConfig.database("blue_papers"))
     db.deleteDoc(s"$paperId:compiler") recover {

--- a/blue-core/src/main/scala/gnieh/blue/http/CouchSupport.scala
+++ b/blue-core/src/main/scala/gnieh/blue/http/CouchSupport.scala
@@ -40,21 +40,21 @@ trait CouchSupport {
     new CouchConfiguration(config)
 
   /** Returns the current couch session object to issue queries to the database */
-  def couchSession(implicit talk: HTalk): CouchSession =
+  def couchSession(implicit talk: HTalk): CookieSession =
     talk.ses.get(SessionKeys.Couch).collect {
-      case sess: CouchSession => sess
+      case sess: CookieSession => sess
     } match {
       case Some(sess) => sess
       case None =>
         // start and register a new couch session
-        val sess = couchConfig.couch.startSession
+        val sess = couchConfig.couch.startCookieSession
         talk.ses(SessionKeys.Couch) = sess
         sess
     }
 
   /** Indicates whether the current session is a logged in user */
   def loggedIn(implicit talk: HTalk): Try[Boolean] =
-    couchSession.isLoggedIn
+    couchSession.isAuthenticated
 
   /** Indicates whether the current session complies with role name */
   def hasRole(role: String)(implicit talk: HTalk): Try[Boolean] =

--- a/blue-core/src/main/scala/gnieh/blue/http/impl/ExtensibleApp.scala
+++ b/blue-core/src/main/scala/gnieh/blue/http/impl/ExtensibleApp.scala
@@ -33,7 +33,7 @@ import scala.collection.{ mutable => mu }
 
 import com.typesafe.config.Config
 
-import gnieh.sohva.control.CouchSession
+import gnieh.sohva.control.CookieSession
 
 /** The rest interface may be extended by \BlueLaTeX modules.
  *  Theses module simply need to register services implementing this trait
@@ -70,7 +70,7 @@ class ExtensibleApp(config: Config, system: ActorSystem) extends HApp {
 
   override def onSessionInvalidate(sid: String, data: Map[Any, Any]) {
     // logout the couchdb session if any
-    for(session <- data.get(SessionKeys.Couch).collect { case s: CouchSession => s}) {
+    for(session <- data.get(SessionKeys.Couch).collect { case s: CookieSession => s}) {
       session.logout
     }
     // notify dispatchers that the user left

--- a/blue-sync/src/main/scala/gnieh/blue/sync/impl/SyncApi.scala
+++ b/blue-sync/src/main/scala/gnieh/blue/sync/impl/SyncApi.scala
@@ -17,29 +17,23 @@ package gnieh.blue
 package sync
 package impl
 
-import scala.util.parsing.combinator._
+import http._
+import common._
+import let._
 
-/** A simple parser for Edit commands.
- * @author Lucas Satabin
+import com.typesafe.config.Config
+
+/** The synchronization service API exposes an interface for clients
+ *  to synchronize their paper
  *
+ *  @author Lucas Satabin
  */
-object EditCommandParsers extends RegexParsers {
+class SyncApi(config: Config, synchroServer: SynchroServer, logger: Logger) extends RestApi {
 
-  def parseEdits(input: String): List[Edit] =
-    parseAll(repsep(edit, '\t'), input) match {
-      case Success(res, _) => res
-      case f               => Nil
-    }
-
-  lazy val edit: Parser[Edit] =
-    ("+" ~> data ^^ Add
-      | "-" ~> number ^^ Delete
-      | "=" ~> number ^^ Equality)
-
-  private lazy val number: Parser[Int] =
-    "[0-9]+".r ^^ (_.toInt)
-
-  private lazy val data: Parser[String] =
-    "([-A-Za-z0-9_.!~*'();/?:@&=+$,# ]|%[A-Fa-f0-9]{2})+".r
+  POST {
+    case p"papers/$paperid/q" =>
+      new QLet(paperid, synchroServer, config, logger)
+  }
 
 }
+

--- a/blue-sync/src/main/scala/gnieh/blue/sync/impl/SyncServer.scala
+++ b/blue-sync/src/main/scala/gnieh/blue/sync/impl/SyncServer.scala
@@ -43,13 +43,14 @@ import scala.util.{Try, Success, Failure}
  */
 class SyncServer(dispatcher: ActorRef, configuration: Config) extends SynchroServer {
 
-  private implicit val formats = DefaultFormats +
-                                 new SyncSessionSerializer +
-                                 new SyncCommandSerializer +
-                                 new SyncActionSerializer +
-                                 new EditSerializer
-
   private implicit val timeout = Timeout(500 millis)
+
+  protected[impl] implicit val formats =
+    DefaultFormats +
+    new SyncSessionSerializer +
+    new SyncCommandSerializer +
+    new SyncActionSerializer +
+    new EditSerializer
 
   def session(data: String): String = {
     val syncSession = Serialization.read[SyncSession](data)

--- a/blue-sync/src/main/scala/gnieh/blue/sync/impl/compat/ProtocolTranslator.scala
+++ b/blue-sync/src/main/scala/gnieh/blue/sync/impl/compat/ProtocolTranslator.scala
@@ -1,0 +1,197 @@
+/*
+ * This file is part of the \BlueLaTeX project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gnieh.blue
+package sync
+package impl
+package compat
+
+import net.liftweb.json._
+
+import scala.util.Try
+
+/** Converts protocols message from and back to mobwrite protocol
+ *
+ *  @author Lucas Satabin
+ */
+object ProtocolTranslator {
+
+  private implicit class ExtractorContext(val sc: StringContext) {
+    object re {
+      val regex = sc.parts.mkString("(.+)").r
+      def unapplySeq(s: String): Option[Seq[String]] =
+        regex.unapplySeq(s)
+    }
+  }
+
+  private object name {
+    def unapply(str: String): Option[String] =
+      if(str.matches("[a-zA-Z][a-zA-Z0-9_:.-]*"))
+        Some(str)
+      else
+        None
+  }
+
+  private object long {
+    def unapply(str: String): Option[Long] =
+      Try(str.toLong).toOption
+  }
+
+  private object obj {
+    def unapply(str: String): Option[JObject] =
+      parseOpt(str).collect { case obj @ JObject(_) => obj }
+  }
+
+  def mobwrite2bluelatex(paperId: String, commands: String): List[SyncSession] = {
+    val result = new StringBuilder
+    def translate(commands: List[String],
+                  currentPeer: Option[String],
+                  currentFile: Option[String],
+                  currentRevision: Option[Long],
+                  commandsAcc: List[Command],
+                  sessionsAcc: List[SyncSession]): List[SyncSession] = commands match {
+
+      case re"(?:u|U):${name(peerId)}" :: rest =>
+        val sessions = currentPeer match {
+          case Some(peer) if commandsAcc.nonEmpty =>
+            SyncSession(peer, paperId, commandsAcc.reverse) :: sessionsAcc
+          case _ =>
+            sessionsAcc
+        }
+        translate(rest, Some(peerId), currentFile, currentRevision, Nil, sessions)
+
+      case re"(?:f|F):${long(rev)}:${name(file)}" :: rest =>
+        translate(rest, currentPeer, Some(file), Some(rev), commandsAcc, sessionsAcc)
+
+      case re"d:${long(rev)}:$delta" :: rest =>
+        val commands = (currentFile, currentRevision) match {
+          case (Some(file), Some(frev)) =>
+            val edits = EditCommandParsers.parseEdits(delta)
+            SyncCommand(file, frev, Delta(rev, edits, false)) :: commandsAcc
+          case (Some(file), None) =>
+            val edits = EditCommandParsers.parseEdits(delta)
+            SyncCommand(file, -1, Delta(rev, edits, false)) :: commandsAcc
+          case _ =>
+            commandsAcc
+        }
+        translate(rest, currentPeer, currentFile, currentRevision, commands, sessionsAcc)
+
+      case re"D:${long(rev)}:$delta" :: rest =>
+        val commands = (currentFile, currentRevision) match {
+          case (Some(file), Some(frev)) =>
+            val edits = EditCommandParsers.parseEdits(delta)
+            SyncCommand(file, frev, Delta(rev, edits, true)) :: commandsAcc
+          case (Some(file), None) =>
+            val edits = EditCommandParsers.parseEdits(delta)
+            SyncCommand(file, -1, Delta(rev, edits, true)) :: commandsAcc
+          case _ =>
+            commandsAcc
+        }
+        translate(rest, currentPeer, currentFile, currentRevision, commands, sessionsAcc)
+
+      case re"r:${long(rev)}:$content" :: rest =>
+        val commands = (currentFile, currentRevision) match {
+          case (Some(file), Some(frev)) =>
+            SyncCommand(file, frev, Raw(rev, content, false)) :: commandsAcc
+          case (Some(file), None) =>
+            SyncCommand(file, -1, Raw(rev, content, false)) :: commandsAcc
+          case _ =>
+            commandsAcc
+        }
+        translate(rest, currentPeer, currentFile, currentRevision, commands, sessionsAcc)
+
+      case re"R:${long(rev)}:$content" :: rest =>
+        val commands = (currentFile, currentRevision) match {
+          case (Some(file), Some(frev)) =>
+            SyncCommand(file, frev, Raw(rev, content, true)) :: commandsAcc
+          case (Some(file), None) =>
+            SyncCommand(file, -1, Raw(rev, content, true)) :: commandsAcc
+          case _ =>
+            commandsAcc
+        }
+        translate(rest, currentPeer, currentFile, currentRevision, commands, sessionsAcc)
+
+      case re"(?:n|N):${name(file)}" :: rest =>
+        val commands = SyncCommand(file, -1, Nullify) :: commandsAcc
+        translate(rest, currentPeer, currentFile, currentRevision, commands, sessionsAcc)
+
+      case re"(?:m|M):${obj(content)}" :: rest =>
+        val commands = Message(currentPeer.getOrElse(""), content, true, currentFile) :: commandsAcc
+        translate(rest, currentPeer, currentPeer, currentRevision, commands, sessionsAcc)
+
+      case _ :: rest =>
+        // simply ignore unknown commands
+        translate(rest, currentPeer, currentPeer, currentRevision, commandsAcc, sessionsAcc)
+
+      case Nil =>
+        val sessions = currentPeer match {
+          case Some(peer) if commandsAcc.nonEmpty =>
+            SyncSession(peer, paperId, commandsAcc.reverse) :: sessionsAcc
+          case _ =>
+            sessionsAcc
+        }
+        sessions.reverse
+
+    }
+    translate(commands.split("\n").toList, None, None, None, Nil, Nil)
+  }
+
+  def bluelatex2mobwrite(session: SyncSession): (String, String) = {
+    val SyncSession(peerId, paperId, commands) = session
+    val result = new StringBuilder
+    for(command <- commands)
+      command match {
+        case SyncCommand(filename, lastRevision, action) =>
+          action match {
+            case Delta(newRevision, data, true) =>
+              result ++= s"""U:$peerId
+                            |F:$lastRevision:$filename
+                            |D:$newRevision:${data.mkString("\t")}
+                            |""".stripMargin
+            case Delta(newRevision, data, false) =>
+              result ++= s"""U:$peerId
+                            |F:$lastRevision:$filename
+                            |d:$newRevision:${data.mkString("\t")}
+                            |""".stripMargin
+            case Raw(newRevision, data, true) =>
+              result ++= s"""U:$peerId
+                            |F:$lastRevision:$filename
+                            |R:$data
+                            |""".stripMargin
+            case Raw(newRevision, data, false) =>
+              result ++= s"""U:$peerId
+                            |F:$lastRevision:$filename
+                            |r:$data
+                            |""".stripMargin
+            case Nullify =>
+              result ++= s"""U:$peerId
+                            |N:$filename
+                            |""".stripMargin
+          }
+        case Message(peerId, obj, reply, Some(file)) =>
+          result ++= s"""U:$peerId
+                        |F:$file
+                        |M:${compact(render(obj))}
+                        |""".stripMargin
+        case Message(peerId, obj, reply, None) =>
+          result ++= s"""U:$peerId
+                        |M:${compact(render(obj))}
+                        |""".stripMargin
+      }
+    (paperId, result.toString)
+  }
+
+}
+

--- a/blue-sync/src/main/scala/gnieh/blue/sync/impl/let/QLet.scala
+++ b/blue-sync/src/main/scala/gnieh/blue/sync/impl/let/QLet.scala
@@ -1,0 +1,53 @@
+/*
+ * This file is part of the \BlueLaTeX project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gnieh.blue
+package sync
+package impl
+package let
+
+import common._
+import http._
+
+import tiscaf._
+
+import com.typesafe.config.Config
+
+import scala.util.Try
+
+import gnieh.sohva.UserInfo
+
+/** Legacy compatibility let, allowing mobwrite clients to synchornize papers
+ *  with the new implementation.
+ *  This let converts from the legacy protocol to the new one before sending the commands to the
+ *  synchronization server, and convert it back to the old protocol before sending it back
+ *  to the client.
+ *
+ *  It assumes that the client respects following conventions:
+ *   - user name (sent via `F:`) must be of the form `<paper_id>/<file>`
+ *
+ *  @author Lucas Satabin
+ */
+class QLet(paperId: String, synchroServer: SynchroServer, config: Config, logger: Logger) extends SyncRoleLet(paperId, config, logger) {
+
+  def roleAct(user: UserInfo, role: PaperRole)(implicit talk: HTalk): Try[Any] = role match {
+    case Author =>
+      ???
+    case _ =>
+      ???
+  }
+
+}
+

--- a/blue-sync/src/test/scala/gnieh/blue/unit/CompatibilityTests.scala
+++ b/blue-sync/src/test/scala/gnieh/blue/unit/CompatibilityTests.scala
@@ -1,0 +1,196 @@
+
+/*
+ * This file is part of the \BlueLaTeX project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gnieh.blue
+package sync
+package impl
+package compat
+package unit
+
+import org.scalatest._
+
+import ProtocolTranslator._
+
+import net.liftweb.json.JsonDSL._
+
+/** Tests the compatibility conversions between mobwrite and blue-sync messages.
+ */
+class CompatibilityTests extends FlatSpec with ShouldMatchers {
+
+  "converting a mobwrite session to blue-sync session" should "be correct" in {
+    val mobwrite = """u:fraser
+                     |F:34:file1.tex
+                     |d:41:=200	-7	+Hello	=100
+                     |F:53:file2.tex
+                     |d:90:=123	+Fool	=296
+                     |""".stripMargin
+    val paperId = "paper_id"
+
+    val session =
+      SyncSession(
+        "fraser",
+        "paper_id",
+        List(
+          SyncCommand(
+            "file1.tex",
+            34,
+            Delta(
+              41,
+              List(Equality(200), Delete(7), Add("Hello"), Equality(100)),
+              false
+            )
+          ),
+          SyncCommand(
+            "file2.tex",
+            53,
+            Delta(
+              90,
+              List(Equality(123), Add("Fool"), Equality(296)),
+              false
+            )
+          )
+        )
+      )
+
+    val converted = mobwrite2bluelatex(paperId, mobwrite)
+
+    converted should be(List(session))
+
+  }
+
+  "converting a blue-sync session into mobwrite messages" should "be correct" in {
+
+    val mobwrite = """U:fraser
+                     |F:34:file1.tex
+                     |d:41:=200	-7	+Hello	=100
+                     |U:fraser
+                     |F:53:file2.tex
+                     |d:90:=123	+Fool	=296
+                     |""".stripMargin
+    val paperId = "paper_id"
+
+    val session =
+      SyncSession(
+        "fraser",
+        "paper_id",
+        List(
+          SyncCommand(
+            "file1.tex",
+            34,
+            Delta(
+              41,
+              List(Equality(200), Delete(7), Add("Hello"), Equality(100)),
+              false
+            )
+          ),
+          SyncCommand(
+            "file2.tex",
+            53,
+            Delta(
+              90,
+              List(Equality(123), Add("Fool"), Equality(296)),
+              false
+            )
+          )
+        )
+      )
+
+    val (convertedId, converted) = bluelatex2mobwrite(session)
+
+    convertedId should be(paperId)
+    converted should be(mobwrite)
+
+  }
+
+  "several sessions" should "be correctly transformed to blue-sync protocol" in {
+    val mobwrite = """U:fraser
+                     |F:12:file1
+                     |M:{"toto": true, "gnieh": 23, "plop": {"toto": "gruik" }}
+                     |F:13:file2
+                     |n:file
+                     |U:toto
+                     |n:plop
+                     |""".stripMargin
+
+    val paperId = "paper_id"
+
+    val sessions = List(
+      SyncSession(
+        "fraser",
+        paperId,
+        List(
+          Message("fraser", ("toto" -> true) ~ ("gnieh" -> 23) ~ ("plop" -> ("toto" -> "gruik")), true, Some("file1")),
+          SyncCommand("file", -1, Nullify)
+        )
+      ),
+      SyncSession(
+        "toto",
+        paperId,
+        List(
+          SyncCommand("plop", -1, Nullify)
+        )
+      )
+    )
+
+    val converted = mobwrite2bluelatex(paperId, mobwrite)
+
+    converted should be(sessions)
+
+  }
+
+  it should "be correctly transformed to mobwrite protocol" in {
+    val mobwrite = """U:fraser
+                     |F:file1
+                     |M:{"toto":true,"gnieh":23,"plop":{"toto":"gruik"}}
+                     |U:fraser
+                     |N:file
+                     |U:toto
+                     |M:{"toto":true}
+                     |U:toto
+                     |N:plop
+                     |""".stripMargin
+
+    val paperId = "paper_id"
+
+    val session1 = SyncSession(
+      "fraser",
+      paperId,
+      List(
+        Message("fraser", ("toto" -> true) ~ ("gnieh" -> 23) ~ ("plop" -> ("toto" -> "gruik")), true, Some("file1")),
+        SyncCommand("file", -1, Nullify)
+      )
+    )
+
+    val session2 = SyncSession(
+      "toto",
+      paperId,
+      List(
+        Message("toto", ("toto" -> true), true, None),
+        SyncCommand("plop", -1, Nullify)
+      )
+    )
+
+    val (convertedId1, converted1) = bluelatex2mobwrite(session1)
+    val (convertedId2, converted2) = bluelatex2mobwrite(session2)
+
+    convertedId1 should be(paperId)
+    convertedId2 should be(paperId)
+    (converted1 + converted2) should be(mobwrite)
+
+  }
+
+}
+

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -61,8 +61,8 @@ class BlueBuild extends Build with Pack with Server with Tests {
 
   lazy val commonDeps = Seq(
     "com.typesafe.akka" %% "akka-osgi" % "2.2.3",
-    "org.gnieh" %% "sohva-client" % "0.5-SNAPSHOT",
-    "org.gnieh" %% "diffson" % "0.2-SNAPSHOT",
+    "org.gnieh" %% "sohva-client" % "0.6-SNAPSHOT",
+    "org.gnieh" %% "diffson" % "0.2",
     "javax.mail" % "mail" % "1.4.7",
     "ch.qos.logback" % "logback-classic" % "1.0.13",
     "org.slf4j" % "jcl-over-slf4j" % "1.7.5",


### PR DESCRIPTION
The new protocol is largely inspired by the original line-based
protocol, but has some improvements. This compatibility converter allows
people to convert from and back to the mobwrite protocol to ensure
compatiblity with standard mobwrite clients.
