### PR TITLE
Add SyncTeX API

### DIFF
--- a/blue-compile/src/main/resources/reference.conf
+++ b/blue-compile/src/main/resources/reference.conf
@@ -12,6 +12,8 @@ compiler {
 
   default = pdflatex
 
+  synctex = true
+
   timeout = 30 seconds
 
   interval = 15 seconds

--- a/blue-compile/src/main/scala/gnieh/blue/compile/CompilerSettings.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/CompilerSettings.scala
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package gnieh.blue
+package compile
 
 import gnieh.sohva.IdRev
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/CompilerSettings.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/CompilerSettings.scala
@@ -18,5 +18,5 @@ package compile
 
 import gnieh.sohva.IdRev
 
-case class CompilerSettings(_id: String, compiler: String, timeout: Int, interval: Int) extends IdRev
+case class CompilerSettings(_id: String, compiler: String, synctex: Boolean, timeout: Int, interval: Int) extends IdRev
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/CompilationActor.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/CompilationActor.scala
@@ -96,7 +96,7 @@ class CompilationActor(
       // schedule the next compilation after the configured interval
       context.system.scheduler.scheduleOnce(settings.interval.seconds, self, Compile)
 
-    case settings @ CompilerSettings(_, _, _, _) =>
+    case settings @ CompilerSettings(_, _, _, _, _) =>
       // settings were changed, take them immediately into account
       context.become(receiving(clients, settings))
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/CompilationApi.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/CompilationApi.scala
@@ -64,6 +64,9 @@ class CompilationApi(context: BundleContext, dispatcher: ActorRef, config: Confi
     // return the compilation settings
     case p"papers/$paperid/compiler" =>
       new GetCompilerSettingsLet(paperid, config, logger)
+    // return the SyncTeX file
+    case p"papers/$paperid/synctex" =>
+      new GetSyncTeXLet(paperid, config, logger)
   }
 
   DELETE {

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/CompilationDispatcher.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/CompilationDispatcher.scala
@@ -67,7 +67,7 @@ class CompilationDispatcher(
         logger.log(LogService.LOG_WARNING, s"compiler settings do not exist for paper $paperId")
         // create the settings in the database and returns it
         // by default we compile with pdflatex with a timeout of 30 seconds and an interval of 15 seconds
-        val settings = CompilerSettings(s"$paperId:compiler", "pdflatex", 30, 15)
+        val settings = CompilerSettings(s"$paperId:compiler", "pdflatex", false, 30, 15)
         for(settings <- db.saveDoc(settings))
           // the get method will throw an exception if `None` is returned,
           // this will be catched and transformed into a `Try` instance.

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/SettingsHooks.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/SettingsHooks.scala
@@ -37,6 +37,7 @@ class CreateSettingsHook(config: Config, logger: Logger) extends PaperCreated {
     new CompilerSettings(
       s"$paperId:compiler",
       config.getString("compiler.default"),
+      config.getBoolean("compiler.synctex"),
       config.getSeconds("compiler.timeout"),
       config.getSeconds("compiler.interval")
     )

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/compiler/PdflatexCompiler.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/compiler/PdflatexCompiler.scala
@@ -44,7 +44,7 @@ class PdflatexCompiler(system: ActorSystem, config: Config) extends SystemCompil
   val configuration = new PaperConfiguration(config)
 
   def compile(paperId: String, settings: CompilerSettings)(implicit timeout: Timeout): Try[Boolean] =
-    exec(s"pdflatex -interaction nonstopmode -output-directory ${buildDir(paperId)} ${paperFile(paperId)}",
+    exec(s"pdflatex -interaction nonstopmode -synctex=${if(settings.synctex) 1 else 0} -output-directory ${buildDir(paperId)} ${paperFile(paperId)}",
       configuration.paperDir(paperId)) //, List("TEXINPUT" -> ".:tex/:resources/:$TEXINPUTS"))
 
   def bibtex(paperId: String, settings: CompilerSettings)(implicit timeout: Timeout): Try[Boolean] = {

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetSyncTeXLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetSyncTeXLet.scala
@@ -1,0 +1,67 @@
+/*
+ * This file is part of the \BlueLaTeX project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gnieh.blue
+package compile
+package impl
+package let
+
+import http._
+import common._
+
+import tiscaf._
+
+import com.typesafe.config.Config
+
+import scala.util.Try
+
+import java.io.FileInputStream
+
+
+import resource._
+
+class GetSyncTeXLet(paperId: String, config: Config, logger: Logger) extends SyncRoleLet(paperId, config, logger) {
+
+  import FileProcessing._
+
+  def roleAct(user: UserInfo, role: PaperRole)(implicit talk: HTalk): Try[Any] = role match {
+    case Author =>
+      val syncTeXFile = configuration.buildDir(paperId) / s"$paperId.synctex.gz"
+
+      if (!syncTeXFile.exists)
+        Try(
+          talk
+            .setStatus(HStatus.NotFound)
+            .writeJson(ErrorResponse("not_found", "SyncTeX file not found")))
+      else
+        Try(for(is <- managed(new FileInputStream(syncTeXFile))) {
+          val array =
+            Iterator.continually(is.read).takeWhile(_ != -1). map(_.toByte).toArray
+
+          talk.setContentType("application/gzip")
+            .setContentLength(array.length)
+            .write(array)
+        })
+
+    case _ =>
+      Try(
+        talk
+          .setStatus(HStatus.Forbidden)
+          .writeJson(ErrorResponse("no_sufficient_rights", "Only authors may retrieve SyncTeX data")))
+
+  }
+
+}
+


### PR DESCRIPTION
This API is used by authors to retrieve the generated SyncTeX generated data.
Data are sent gzipped as generated by the LaTeX compiler.
