### PR TITLE
[imp #35] Improved compilation results

### DIFF
--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/CompilationDispatcher.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/CompilationDispatcher.scala
@@ -83,7 +83,7 @@ class CompilationDispatcher(
     case Register(_, client) =>
       // A client tried to registered to an unknown paper identifier,
       // to avoid having dangling request, reply immediately with an error
-      client.complete(Try(false))
+      client.complete(Try(CompilationAborted))
     case _ =>
       // ignore other messages
   }

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/CompilationStatus.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/CompilationStatus.scala
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the \BlueLaTeX project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gnieh.blue
+package compile
+package impl
+
+sealed trait CompilationStatus
+
+case object CompilationSucceeded extends CompilationStatus
+
+case object CompilationFailed extends CompilationStatus
+
+case object CompilationAborted extends CompilationStatus
+
+case object CompilationUnnecessary extends CompilationStatus
+

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/CompilerLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/CompilerLet.scala
@@ -37,12 +37,27 @@ class CompilerLet(paperId: String, val couch: CouchClient, dispatcher: ActorRef,
 
   def roleAct(user: UserInfo, role: PaperRole)(implicit talk: HTalk): Future[Any] = role match {
     case Author =>
-      val promise = Promise[Boolean]()
+      val promise = Promise[CompilationStatus]()
 
       // register the client with the paper compiler
       dispatcher ! Forward(paperId, Register(user.name, promise))
 
-      promise.future.map(talk.writeJson) recover {
+      promise.future.map {
+        case CompilationSucceeded =>
+          talk.writeJson(true)
+        case CompilationFailed =>
+          talk
+            .setStatus(HStatus.InternalServerError)
+            .writeJson(ErrorResponse("unable_to_compile", "Compilation failed, more details in the compilation log file."))
+        case CompilationAborted =>
+          talk
+            .setStatus(HStatus.ServiceUnavailable)
+            .writeJson(ErrorResponse("unable_to_compile", s"No compilation task started"))
+        case CompilationUnnecessary =>
+          talk
+            .setStatus(HStatus.NotModified)
+            .writeJson(false)
+      } recover {
         case e =>
           logError(s"Unable to compile paper $paperId", e)
           talk

--- a/blue-test/src/it/scala/gnieh/blue/scenario/compiler/Compilation.scala
+++ b/blue-test/src/it/scala/gnieh/blue/scenario/compiler/Compilation.scala
@@ -40,10 +40,15 @@ class CompilationSpec extends BlueScenario with SomeUsers with SomePapers {
       loggedin should be(true)
 
       When("he tries to register to a compilation stream")
-      val (res, _) = post[Boolean](List("papers", paper1._id, "compiler"), Map(), headers = Map("Content-Length" -> "0", "Content-Type" -> "application/json"))
+      val exn = evaluating {
+        post[Boolean](List("papers", paper1._id, "compiler"), Map(), headers = Map("Content-Length" -> "0", "Content-Type" -> "application/json"))
+      } should produce[BlueErrorException]
 
       Then("the server authorizes the registration")
-      res should be(false)
+      exn.status should be(503)
+      val error = exn.error
+      error.name should be("unable_to_compile")
+      error.description should be("No compilation task started")
 
     }
 


### PR DESCRIPTION
When subscribing to the compilation channel of a paper, several things
can happen in return:
- the compilation succeeded, in which case the server says ok by
  returning `true`
- the compilation failed, in which case the server returns an error 500
  (Internal Server Error) with the appropriate error object
- the compilation was not necessary, in which case the server says
  `false` with status 304 (Not Modified)
- the compilation task was not started (typically, nobody joined the
  paper before registering to this compilation channel), in which case
  the server returns an error 509 (Service Unavailable) with the
  appropriate error object
