### PR TITLE
[imp #12] Save paper last modification time

### DIFF
--- a/blue-common/src/main/scala/gnieh/blue/couch/Paper.scala
+++ b/blue-common/src/main/scala/gnieh/blue/couch/Paper.scala
@@ -17,11 +17,14 @@ package gnieh.blue.couch
 
 import gnieh.sohva.IdRev
 
+import java.util.Date
+
 case class Paper(_id: String,
                  title: String,
                  authors: Set[String],
                  reviewers: Set[String],
                  cls: String,
+                 last_modification: Option[Date] = None,
                  references: List[String] = Nil,
                  enabled_modules: List[String] = Nil,
                  tags: List[String] = Nil,

--- a/blue-common/src/main/scala/gnieh/blue/http/BlueLet.scala
+++ b/blue-common/src/main/scala/gnieh/blue/http/BlueLet.scala
@@ -229,7 +229,7 @@ abstract class SyncRoleLet(val paperId: String, config: Config, logger: Logger) 
 
   private def roles(implicit talk: HTalk): Try[Map[String, PaperRole]] =
     couchSession.database(couchConfig.database("blue_papers")).getDocById[Paper](paperId) map {
-      case Some(Paper(_, _, authors, reviewers, _, _, _, _, _)) =>
+      case Some(Paper(_, _, authors, reviewers, _, _, _, _, _, _)) =>
         (authors.map(id => (id, Author)) ++
           reviewers.map(id => (id, Reviewer))).toMap.withDefaultValue(Other)
       case None =>
@@ -258,7 +258,7 @@ abstract class AsyncRoleLet(val paperId: String, config: Config, logger: Logger)
 
   private def roles(implicit talk: HTalk): Try[Map[String, PaperRole]] =
     couchSession.database(couchConfig.database("blue_papers")).getDocById[Paper](paperId) map {
-      case Some(Paper(_, _, authors, reviewers, _, _, _, _, _)) =>
+      case Some(Paper(_, _, authors, reviewers, _, _, _, _, _, _)) =>
         (authors.map(id => (id, Author)) ++
           reviewers.map(id => (id, Reviewer))).toMap.withDefaultValue(Other)
       case None =>

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/CompilationActor.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/CompilationActor.scala
@@ -129,8 +129,8 @@ class CompilationActor(
               newTitle <- texTitle(paperId)
               newClass <- documentClass(paperId)
               p <- paper
-              if p.title != newTitle || p.cls != newClass
-            } db.saveDoc(p.copy(title = newTitle, cls = newClass).withRev(p._rev))
+              if p.title != newTitle || p.cls != newClass || p.last_modification != Some(lastModificationDate)
+            } db.saveDoc(p.copy(title = newTitle, cls = newClass, last_modification = Some(lastModificationDate)).withRev(p._rev))
           }
 
           if(res)
@@ -145,10 +145,10 @@ class CompilationActor(
           client.complete(res)
 
         // if hasBeenModified is false, we are sure that lastCompilationDate is defined
-        val newDate = if (hasBeenModified) lastModificationDate else lastCompilationDate.get
+        val newDate = if (hasBeenModified) Some(lastModificationDate) else lastCompilationDate
 
         // and listen again with an empty list of clients
-        context.become(receiving(Map(), settings, Some(newDate)))
+        context.become(receiving(Map(), settings, newDate))
 
       }
 

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/user/DeleteUserLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/user/DeleteUserLet.scala
@@ -68,7 +68,7 @@ class DeleteUserLet(username: String, context: BundleContext, val couch: CouchCl
 
         // get the papers for which the user is the single author
         val singleAuthor = rows.collect {
-          case Row(_, _, _, Some(Paper(id, _, SingletonSet(name), _, _, _, _, _, _))) if name == userid =>
+          case Row(_, _, _, Some(Paper(id, _, SingletonSet(name), _, _, _, _, _, _, _))) if name == userid =>
             id
         }
 


### PR DESCRIPTION
When we compile the paper, save the last modification time if necessary,
this can be retrieved by the client when asking for project information.
