### PR TITLE
[imp #88] Add paper name to identify it

### DIFF
--- a/blue-common/src/main/scala/gnieh/blue/couch/Paper.scala
+++ b/blue-common/src/main/scala/gnieh/blue/couch/Paper.scala
@@ -20,6 +20,6 @@ import gnieh.sohva.IdRev
 import java.util.Date
 
 case class Paper(_id: String,
-                 title: String,
-                 last_modification: Option[Date] = None) extends IdRev
+                 name: String,
+                 creation_date: Date) extends IdRev
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/CompilationActor.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/CompilationActor.scala
@@ -120,20 +120,6 @@ class CompilationActor(
           // clean the generated png files when compilation succeeded
           for(file <- configuration.buildDir(paperId).filter(_.extension == ".png"))
             file.delete
-          // extract the paper title and update it if necessary
-          // i.e. if it changes since the last version saved in the database
-          val pdfFile = configuration.buildDir(paperId) / s"$paperId.pdf"
-          couchConfig.asAdmin(couch) { session =>
-            val manager = new EntityManager(session.database(couchConfig.database("blue_papers")))
-            for {
-              paper <- manager.getComponent[Paper](paperId)
-              newTitle <- texTitle(paperId)
-              newClass <- documentClass(paperId)
-              p <- paper
-              if p.title != newTitle || p.last_modification != Some(lastModificationDate)
-              _ <- manager.saveComponent(paperId, p.copy(title = newTitle, last_modification = Some(lastModificationDate)).withRev(p._rev))
-            } ()
-          }
 
           if(res)
             CompilationSucceeded

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetPaperInfoLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetPaperInfoLet.scala
@@ -61,8 +61,8 @@ class GetPaperInfoLet(paperid: String, val couch: CouchClient, config: Config, l
       roles <- manager.getComponent[PaperRole](paperid)
     } yield (paper, roles) match {
       // we are sure that the paper has a revision because it comes from the database
-      case (Some(Paper(_, title, _)), Some(roles)) =>
-        talk.writeJson(Map("title" -> title, "authors" -> roles.authors.users, "reviewers" -> roles.reviewers.users), roles._rev.get)
+      case (Some(Paper(_, name, created)), Some(roles)) =>
+        talk.writeJson(Map("name" -> name, "creation_date" -> created, "authors" -> roles.authors.users, "reviewers" -> roles.reviewers.users), roles._rev.get)
       case (_, _) =>
         talk.setStatus(HStatus.NotFound).writeJson(ErrorResponse("not_found", s"Paper $paperid not found"))
     }

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/user/GetUserPapersLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/user/GetUserPapersLet.scala
@@ -53,7 +53,7 @@ class GetUserPapersLet(username: String, val couch: CouchClient, config: Config,
 
       for(papers <- database(blue_papers).getDocsById[Paper](result.map(id => s"${id._1}:core")))
         yield talk.writeJson((result zip papers) map {
-          case ((id, role), Paper(_, title, _)) => Map("id" -> id, "role" -> role, "title" -> title) 
+          case ((id, role), Paper(_, name, created)) => Map("id" -> id, "role" -> role, "name" -> name, "creation_date" -> created)
         })
     }
 

--- a/blue-test/src/it/scala/gnieh/blue/scenario/SomePapers.scala
+++ b/blue-test/src/it/scala/gnieh/blue/scenario/SomePapers.scala
@@ -22,6 +22,8 @@ import couch.{
   UsersGroups
 }
 
+import java.util.Date
+
 import org.scalatest._
 
 import gnieh.sohva.CouchUser
@@ -34,8 +36,8 @@ import gnieh.sohva.CouchUser
 trait SomePapers extends BeforeAndAfterEach {
   this: BlueScenario =>
 
-  val paper1 = Paper("paper1", "Some Paper", Set("glambert"), Set())
-  val paper2 = Paper("paper2", "Some Other Paper", Set("toto"), Set("glambert"))
+  val paper1 = Paper("paper1", "Some Paper", Set("glambert"), Set(), new Date)
+  val paper2 = Paper("paper2", "Some Other Paper", Set("toto"), Set("glambert"), new Date)
 
   val predefinedPapers: List[Paper]
 
@@ -46,7 +48,7 @@ trait SomePapers extends BeforeAndAfterEach {
     try {
       for(paper <- predefinedPapers) {
         paperManager.create(paper._id, None)
-        paperManager.saveComponent(paper._id, BluePaper(s"${paper._id}:core", paper.title))
+        paperManager.saveComponent(paper._id, BluePaper(s"${paper._id}:core", paper.name, paper.creation_date))
         paperManager.saveComponent(paper._id,
           PaperRole(
             s"${paper._id}:roles",
@@ -63,7 +65,7 @@ trait SomePapers extends BeforeAndAfterEach {
     super.afterEach()
   } finally {
     // save the papers
-    for(Paper(id, _, _, _) <- predefinedPapers)
+    for(Paper(id, _, _, _, _) <- predefinedPapers)
       paperManager.deleteEntity(id)
   }
 

--- a/blue-test/src/it/scala/gnieh/blue/scenario/compiler/CompilerSettings.scala
+++ b/blue-test/src/it/scala/gnieh/blue/scenario/compiler/CompilerSettings.scala
@@ -47,7 +47,7 @@ class CompilerSettingsSpec extends BlueScenario with SomeUsers {
 
       When("he creates a new paper")
       val title = "Some Test Paper"
-      val (paperId, _) = post[String](List("papers"), Map("paper_title" -> title))
+      val (paperId, _) = post[String](List("papers"), Map("paper_name" -> title, "paper_title" -> title))
 
       Then("settings are created for the newly created paper")
       val (compilerSettings, headers) = get[CompilerSettings](List("papers", paperId, "compiler"))

--- a/blue-test/src/it/scala/gnieh/blue/scenario/paper/Creation.scala
+++ b/blue-test/src/it/scala/gnieh/blue/scenario/paper/Creation.scala
@@ -40,12 +40,12 @@ class PaperCreationSpec extends BlueScenario with SomeUsers {
 
       When("he creates a new paper")
       val title = "On Writing Tests"
-      val (id, _) = post[String](List("papers"), Map("paper_title" -> title))
+      val (id, _) = post[String](List("papers"), Map("paper_name" -> title, "paper_title" -> title))
 
       Then("the paper can be retrieved from the service")
       val (paper, _) = get[PaperInfo](List("papers", id, "info"))
 
-      paper.title should be(title)
+      paper.name should be(title)
       paper.authors should be(Set(rene.username))
       paper.reviewers should be('empty)
 

--- a/blue-test/src/it/scala/gnieh/blue/scenario/paper/Resources.scala
+++ b/blue-test/src/it/scala/gnieh/blue/scenario/paper/Resources.scala
@@ -45,7 +45,7 @@ class SaveResource extends BlueScenario with SomeUsers {
 
       When("he creates a new paper")
       val title = "On Writing Tests"
-      val (paperid, _) = post[String](List("papers"), Map("paper_title" -> title))
+      val (paperid, _) = post[String](List("papers"), Map("paper_name" -> title, "paper_title" -> title))
 
       val hddFile = new File("src/it/resources/resource.txt")
 

--- a/blue-test/src/main/scala/gnieh/blue/Paper.scala
+++ b/blue-test/src/main/scala/gnieh/blue/Paper.scala
@@ -17,10 +17,13 @@ package gnieh.blue
 
 import gnieh.sohva.IdRev
 
-case class Paper(_id: String,
-                 title: String,
-                 authors: Set[String],
-                 reviewers: Set[String]) extends IdRev
+import java.util.Date
 
-case class PaperInfo(title: String, authors: Set[String], reviewers: Set[String])
+case class Paper(_id: String,
+                 name: String,
+                 authors: Set[String],
+                 reviewers: Set[String],
+                 creation_date: Date) extends IdRev
+
+case class PaperInfo(name: String, authors: Set[String], reviewers: Set[String], creation_date: Date)
 

--- a/blue-test/src/main/scala/gnieh/blue/UserRole.scala
+++ b/blue-test/src/main/scala/gnieh/blue/UserRole.scala
@@ -15,4 +15,4 @@
  */
 package gnieh.blue
 
-case class UserRole(id: String, title: String, role: String)
+case class UserRole(id: String, name: String, role: String)

--- a/blue-web/src/main/resources/webapp/css/papers.css
+++ b/blue-web/src/main/resources/webapp/css/papers.css
@@ -123,7 +123,7 @@
     height: 34px;
     padding: 7px;
 }
-#paper_list.list .paper .title, #paper_list.list .paper .date, #paper_list.list .paper .options, #paper_list.list .paper .tags, #paper_list.list .paper .role {
+#paper_list.list .paper .name, #paper_list.list .paper .date, #paper_list.list .paper .options, #paper_list.list .paper .tags, #paper_list.list .paper .role {
     position: relative;
     display: table-cell;
     vertical-align: middle;
@@ -131,7 +131,7 @@
     border-left: 1px solid #ddd;
     min-height: 34px;
 }
-#paper_list.list .paper .title{
+#paper_list.list .paper .name{
     border-left: 0;
 }
 #paper_list.list .paper .date {
@@ -187,7 +187,7 @@
 #paper_list.vignette .paper img {
     width: 100%;
 }
-#paper_list.vignette .paper .title,#paper_list.vignette .paper .date, #paper_list.vignette .paper .tags, #paper_list.vignette .paper .options {
+#paper_list.vignette .paper .name,#paper_list.vignette .paper .date, #paper_list.vignette .paper .tags, #paper_list.vignette .paper .options {
     position: absolute;
     bottom: 0;
     background: #025097;
@@ -203,7 +203,7 @@
     -o-transition: bottom 0.2s;
     transition: bottom 0.2s;
 }
-#paper_list.vignette .paper:hover .title {
+#paper_list.vignette .paper:hover .name {
     bottom: 33px;
 }
 #paper_list.vignette .paper .tags {

--- a/blue-web/src/main/resources/webapp/i18n/resources-locale_default.js
+++ b/blue-web/src/main/resources/webapp/i18n/resources-locale_default.js
@@ -175,6 +175,11 @@
         "description":"Title"
     },
     {
+        "key":"_Name_",
+        "value":"Name",
+        "description":"Name"
+    },
+    {
         "key":"_Template_",
         "value":"Template",
         "description":"Template"

--- a/blue-web/src/main/resources/webapp/i18n/resources-locale_fr.js
+++ b/blue-web/src/main/resources/webapp/i18n/resources-locale_fr.js
@@ -170,6 +170,11 @@
         "description":"Title"
     },
     {
+        "key":"_Name_",
+        "value":"Nom",
+        "description":"Name"
+    },
+    {
         "key":"_Template_",
         "value":"Modèle",
         "description":"Template"

--- a/blue-web/src/main/resources/webapp/js/paper/controllers/InitPaperController.js
+++ b/blue-web/src/main/resources/webapp/js/paper/controllers/InitPaperController.js
@@ -53,7 +53,7 @@ angular.module('bluelatex.Paper.Controllers.InitPaper', ['bluelatex.Paper.Servic
       */
       getPaperInfo().then(function(paper) {
         // change the title of the page
-        $rootScope.pageTitle = "Paper - " + paper.title;
+        $rootScope.pageTitle = "Paper - " + paper.name;
 
         // change the type of paper
         $scope.paperType = "latex";

--- a/blue-web/src/main/resources/webapp/js/paper/controllers/NewPaperController.js
+++ b/blue-web/src/main/resources/webapp/js/paper/controllers/NewPaperController.js
@@ -19,14 +19,15 @@ angular.module('bluelatex.Paper.Controllers.NewPaper', [])
     function ($scope, $location, PaperService, $log, MessagesService) {
       var paper = {
         template: "article",
-        title: ''
+        title: '',
+        name: ''
       };
 
       $scope.saving=false;
 
       $scope.paper = paper;
 
-      /* Hard-coded for now, but will be dynamically loaded  later */
+      /* Hard-coded for now, but will be dynamically loaded later */
       $scope.templates = {
         "article": {
           "name": "Article",

--- a/blue-web/src/main/resources/webapp/js/paper/controllers/PapersController.js
+++ b/blue-web/src/main/resources/webapp/js/paper/controllers/PapersController.js
@@ -31,8 +31,8 @@ angular.module('bluelatex.Paper.Controllers.Papers', ['ngStorage','bluelatex.Pap
 
       $scope.predicate = $localStorage.userPaperPredicate;
       if($scope.predicate == null)
-        $scope.predicate = 'title';
-        
+        $scope.predicate = 'name';
+
       $scope.$watch("predicate", function(value) {
         $localStorage.userPaperPredicate = value;
       });
@@ -163,7 +163,7 @@ angular.module('bluelatex.Paper.Controllers.Papers', ['ngStorage','bluelatex.Pap
       * Delete a paper
       */
       $scope.delete = function (paper) {
-        if(!confirm(localize.getLocalizedString('_Delete_paper_confirm_', paper.title))) return;
+        if(!confirm(localize.getLocalizedString('_Delete_paper_confirm_', paper.name))) return;
         PaperService.delete(paper.id).then(function (data) {
           if (data.response == true) {
             $scope.papers.splice($scope.papers.indexOf(paper), 1);

--- a/blue-web/src/main/resources/webapp/partials/edit_paper.html
+++ b/blue-web/src/main/resources/webapp/partials/edit_paper.html
@@ -4,13 +4,13 @@
         <div bl-messages></div>
         <div class="grid">
             <div class="col c1-3">
-                <label for="title" data-i18n="_Title_">Title</label>
+                <label for="name" data-i18n="_Name_">Title</label>
             </div>
             <div class="col c2-3 form-group">
-              <input class="form-control" id="title" disabled="disabled" name="title" type="text" autofocus
-                data-i18n-attr="_Title_|placeholder" required ng-model="paper.title" />
+              <input class="form-control" id="name" disabled="disabled" name="name" type="text" autofocus
+                data-i18n-attr="_Name_|placeholder" required ng-model="paper.name" />
                 <span class="control-label"
-                  ng-show="editPaperForm.title.$error.required" data-i18n="_Required_"></span>
+                  ng-show="editPaperForm.name.$error.required" data-i18n="_Required_"></span>
             </div>
         </div>
         <div class="grid">

--- a/blue-web/src/main/resources/webapp/partials/new_paper.html
+++ b/blue-web/src/main/resources/webapp/partials/new_paper.html
@@ -4,13 +4,25 @@
         <div bl-messages></div>
         <div class="grid">
             <div class="col c1-3">
+                <label for="name" data-i18n="_Name_">Title</label>
+                <span class="control-label"
+                  ng-show="newPaperForm.name.$error.required" data-i18n="_Required_"></span>
+            </div>
+            <div class="col c2-3 form-group"
+              ng-class="{'has-error': newPaperForm.name.$invalid}">
+              <input class="form-control" id="name" name="name" type="text" autofocus
+                data-i18n-attr="_Name_|placeholder" required ng-model="paper.paper_name" />
+            </div>
+        </div>
+        <div class="grid">
+            <div class="col c1-3">
                 <label for="title" data-i18n="_Title_">Title</label>
                 <span class="control-label"
                   ng-show="newPaperForm.title.$error.required" data-i18n="_Required_"></span>
             </div>
             <div class="col c2-3 form-group"
               ng-class="{'has-error': newPaperForm.title.$invalid}">
-              <input class="form-control" id="title" name="title" type="text" autofocus
+              <input class="form-control" id="title" name="title" type="text"
                 data-i18n-attr="_Title_|placeholder" required ng-model="paper.paper_title" />
             </div>
         </div>

--- a/blue-web/src/main/resources/webapp/partials/papers.html
+++ b/blue-web/src/main/resources/webapp/partials/papers.html
@@ -21,7 +21,7 @@
                 <span data-i18n="_Sort_by_"></span>
                 <select ng-model="predicate">
                     <option value="id" data-i18n="_Id_"></option>
-                    <option value="title" data-i18n="_Title_"></option>
+                    <option value="name" data-i18n="_Name_"></option>
                     <option value="role" data-i18n="_Role_"></option>
                     <!--<option value="date" data-i18n="_Date_"></option>-->
                 </select>
@@ -103,7 +103,7 @@
         <div id="paper_list" ng-class="display_style">
             <div bl-messages></div>
             <div class="paper header" ng-if="display_style=='list'">
-                <div class="title" data-i18n="_Title_"  ng-class="{'predicate': predicate=='title', 'reverse': reverse=='false' || reverse== false}" ng-click="orderBy('title', (reverse=='false' || reverse== false)?true:false)"></div>
+                <div class="name" data-i18n="_Name_"  ng-class="{'predicate': predicate=='name', 'reverse': reverse=='false' || reverse== false}" ng-click="orderBy('name', (reverse=='false' || reverse== false)?true:false)"></div>
                 <!--<div class="date" data-i18n="_Date_" ng-class="{'predicate': predicate=='date', 'reverse': !reverse}" ng-click="orderBy('date', (reverse=='false' || reverse== false)?true:false)"></div>-->
                 <div class="role" data-i18n="_Role_" ng-class="{'predicate': predicate=='role', 'reverse': reverse=='false' || reverse== false}" ng-click="orderBy('role', (reverse=='false' || reverse== false)?true:false)"></div>
                 <!--<div class="tags" data-i18n="_Tags_"></div>-->
@@ -122,8 +122,8 @@
                     </a>
                 </div>
                 -->
-                <div class="title">
-                    <a href="#/paper/{{paper.id}}">{{paper.title}}</a>
+                <div class="name">
+                    <a href="#/paper/{{paper.id}}">{{paper.name}}</a>
                 </div>
                 <!--<div class="date">
                     <a href="#/paper/{{paper.id}}">{{paper.date | date:'MM/dd/yyyy'}}</a>


### PR DESCRIPTION
When a user creates a paper, he must give a name that is used in paper
list for further reference to it.

Using a name that is not the title extracted from the source is better
for several reasons:
- Using a simple regular expression to extract the title from the
  source file is not a really robust method,
- Source title may contain control sequences that are not really user
  friendly to display,
- Several papers may have similar titles which will make it more
  difficult to distinguish between them.

For all these reasons we found it preferable to ask for a name that the
user can freely chose and edit.
