### PR TITLE
[imp #93] Make default file names user-friendly

### DIFF
--- a/blue-common/src/main/scala/gnieh/blue/common/PaperConfiguration.scala
+++ b/blue-common/src/main/scala/gnieh/blue/common/PaperConfiguration.scala
@@ -28,13 +28,13 @@ class PaperConfiguration(val config: Config) {
     new File(config.getString("blue.paper.directory")) / paperId
 
   def paperFile(paperId: String): File =
-    paperDir(paperId) / s"$paperId.tex"
+    paperDir(paperId) / "main.tex"
 
   def resource(paperId: String, resourceName: String): File =
     paperDir(paperId) / resourceName
 
   def bibFile(paperId: String): File =
-    paperDir(paperId) / s"$paperId.bib"
+    paperDir(paperId) / "references.bib"
 
   def clsDir: File =
     new File(config.getString("blue.paper.classes"))

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/CompilationActor.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/CompilationActor.scala
@@ -164,16 +164,7 @@ class CompilationActor(
 
   }
 
-  def texTitle(paperId: String) =
-    configuration.paperFile(paperId)
-      .extractFirst("\\\\title.([^}]+)".r)
-
-  def documentClass(paperId: String) =
-    configuration.paperFile(paperId)
-      .extractFirst("""\\documentclass(?:\[[^\[]*\])?.([^}]+)""".r)
-
 }
 
 case object Compile
 case class Register(username: String, response: Promise[CompilationStatus])
-

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetLogLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetLogLet.scala
@@ -52,7 +52,7 @@ class GetLogLet(paperId: String, val couch: CouchClient, config: Config, logger:
 
       import FileUtils._
 
-      val logFile = configuration.buildDir(paperId) / s"$paperId.log"
+      val logFile = configuration.buildDir(paperId) / s"main.log"
 
       if(logFile.exists)
         Try(for(log <- managed(Source.fromFile(logFile)(GetLogLet.codec))) {

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPagesLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPagesLet.scala
@@ -50,7 +50,7 @@ class GetPagesLet(paperId: String, val couch: CouchClient, config: Config, logge
     case Author | Reviewer =>
 
       // the generated pdf file
-      val pdfFile = configuration.buildDir(paperId) / s"$paperId.pdf"
+      val pdfFile = configuration.buildDir(paperId) / s"main.pdf"
 
       if(pdfFile.exists) {
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPdfLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPdfLet.scala
@@ -41,7 +41,7 @@ class GetPdfLet(paperId: String, val couch: CouchClient, config: Config, logger:
 
       import FileUtils._
 
-      val pdfFile = configuration.buildDir(paperId) / s"$paperId.pdf"
+      val pdfFile = configuration.buildDir(paperId) / s"main.pdf"
 
       if(pdfFile.exists)
         Try(for(pdf <- managed(new FileInputStream(pdfFile))) {

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPngLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPngLet.scala
@@ -52,7 +52,7 @@ class GetPngLet(paperId: String, page: Int, val couch: CouchClient, config: Conf
 
         // the generated pdf file
         val paperDir = configuration.buildDir(paperId)
-        val pdfFile = paperDir / s"$paperId.pdf"
+        val pdfFile = paperDir / s"main.pdf"
 
         if (pdfFile.exists) {
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetSyncTeXLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetSyncTeXLet.scala
@@ -40,7 +40,7 @@ class GetSyncTeXLet(paperId: String, val couch: CouchClient, config: Config, log
 
   def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Any] = role match {
     case Author =>
-      val syncTeXFile = configuration.buildDir(paperId) / s"$paperId.synctex.gz"
+      val syncTeXFile = configuration.buildDir(paperId) / s"main.synctex.gz"
 
       if (!syncTeXFile.exists)
         Try(

--- a/blue-web/src/main/resources/webapp/js/paper/controllers/LatexPaperController.js
+++ b/blue-web/src/main/resources/webapp/js/paper/controllers/LatexPaperController.js
@@ -193,7 +193,7 @@ angular.module('bluelatex.Paper.Controllers.LatexPaper', ['angularFileUpload','b
         return PaperService.getSynchronized($scope.paperId).then(function (data) {
           $scope.synchronizedFiles = data;
           for (var i = 0; i < $scope.synchronizedFiles.length; i++) {
-            if($scope.synchronizedFiles[i].title == $scope.paperId + ".tex") {
+            if($scope.synchronizedFiles[i].title == "main.tex") {
               $scope.currentFile = $scope.synchronizedFiles[i];
               break;
             }

--- a/blue-web/src/main/resources/webapp/partials/paper/latex/author.html
+++ b/blue-web/src/main/resources/webapp/partials/paper/latex/author.html
@@ -196,7 +196,7 @@
             <div class="file" ng-repeat="file in synchronizedFiles | orderBy :'name': 'false'" ng-class="{current: file==currentFile}">
               <div class="icon type-{{file.extension}}"></div>
               <div class="label" ng-click="changeFile(file)">{{file.name}}<span class="extension" ng-if="file.extension">.{{file.extension}}</span></div>
-              <button ng-click="removeSynchronisedFile(file)" class="icon-delete" ng-if="file.name != $routeParams.id"></button>
+              <button ng-click="removeSynchronisedFile(file)" class="icon-delete" ng-if="file.name != 'main' && file.name != $routeParams.id"></button>
               <div class="clear"></div>
             </div>
             <div class="file" ng-if="synchronizedFiles.length == 0" data-i18n="_No_synchronized_file_found_"></div>

--- a/src/main/templates/generic.tex.mustache
+++ b/src/main/templates/generic.tex.mustache
@@ -26,5 +26,5 @@ Some text
 \section{Second Section}
 
 % to add the bibliography, uncomment the following line
-%\bibliography{<% id %>}
+%\bibliography{references}
 \end{document}

--- a/src/main/templates/llncs.tex.mustache
+++ b/src/main/templates/llncs.tex.mustache
@@ -31,6 +31,6 @@ blablabla
 % The following two commands are all you need in the
 % initial runs of your .tex file to
 % produce the bibliography for the citations in your paper.
-%\bibliography{<% id %>}
+%\bibliography{references}
 
 \end{document}

--- a/src/main/templates/sig-alternate.tex.mustache
+++ b/src/main/templates/sig-alternate.tex.mustache
@@ -58,6 +58,6 @@ blablabla
 % initial runs of your .tex file to
 % produce the bibliography for the citations in your paper.
 %\bibliographystyle{abbrv}
-%\bibliography{<% id %>}
+%\bibliography{references}
 
 \end{document}

--- a/src/main/templates/sigproc-sp.tex.mustache
+++ b/src/main/templates/sigproc-sp.tex.mustache
@@ -53,6 +53,6 @@ blablabla
 % initial runs of your .tex file to
 % produce the bibliography for the citations in your paper.
 %\bibliographystyle{abbrv}
-%\bibliography{<% id %>}
+%\bibliography{references}
 
 \end{document}


### PR DESCRIPTION
Instead of using the paper identifier as default names for the files
automatically created with a new paper, it is better to use more
human-readable names such as `main.tex` and `references.bib`.
