### PR TITLE
[imp #87] Suggest filename for downloaded content

### DIFF
--- a/blue-common/src/main/scala/gnieh/blue/http/BlueLet.scala
+++ b/blue-common/src/main/scala/gnieh/blue/http/BlueLet.scala
@@ -51,6 +51,8 @@ import scala.language.implicitConversions
 
 import scala.collection.JavaConverters._
 
+import java.net.URLEncoder
+
 object BlueLet {
 
   /** The formats to (de)serialize json objects. You may override it if you need specific serializers */
@@ -77,6 +79,10 @@ object BlueLet {
         case _                         => false
       }
     }
+
+    /** Sets the correct `Content-Disposition` header with suggested filename for the client */
+    def setFilename(name: String): HTalk =
+      talk.setHeader("Content-Disposition", s"""attachment; filename="$name"; filename*=utf-8''${URLEncoder.encode(name, "UTF-8")}""")
 
     /** Serializes the value to its json representation and writes the response to the client,
      *  corrrectly setting the result type and length */

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetLogLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetLogLet.scala
@@ -61,6 +61,7 @@ class GetLogLet(paperId: String, val couch: CouchClient, config: Config, logger:
 
           talk.setContentType("${HMime.txt};charset=${talk.encoding}")
             .setContentLength(text.size)
+            .setFilename(logFile.getName)
             .write(text)
         })
       else

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPdfLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPdfLet.scala
@@ -50,6 +50,7 @@ class GetPdfLet(paperId: String, val couch: CouchClient, config: Config, logger:
 
           talk.setContentType(HMime.pdf)
             .setContentLength(array.length)
+            .setFilename(pdfFile.getName)
             .write(array)
         })
       else

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/BackupPaperLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/BackupPaperLet.scala
@@ -38,6 +38,8 @@ import http._
 import common._
 import permission._
 
+import couch.Paper
+
 import scala.util.Try
 
 import gnieh.sohva.control.CouchClient
@@ -48,48 +50,53 @@ import gnieh.sohva.control.CouchClient
  */
 class BackupPaperLet(format: String, paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncRoleLet(paperId, config, logger) {
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Unit] = Try(role match {
+  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Unit] = role match {
     case Author =>
-      // only authors may backup the paper sources
-      import FileUtils._
-      val toZip =
-        configuration.paperDir(paperId).filter(f => !f.isDirectory && !f.isHidden && !f.isTeXTemporary).toArray
+      entityManager("blue_papers").getComponent[Paper](paperId) map {
+        case Some(Paper(_, name, _)) =>
+          // only authors may backup the paper sources
+          import FileUtils._
+          val toZip =
+            configuration.paperDir(paperId).filter(f => !f.isDirectory && !f.isHidden && !f.isTeXTemporary).toArray
 
-      //logger.debug("Files to zip: " + toZip.mkString(", "))
-
-      for(os <- managed(new ByteArrayOutputStream);
-          zip <- managed(new ZipOutputStream(os))) {
-        for (file <- toZip) {
-          for(fis <- managed(new FileInputStream(file))) {
-            try {
-              // create a new entry
-              zip.putNextEntry(new ZipEntry(file.getName))
-              // write into this entry
-              val length = fis.available
-              for (i <- 0 until length)
-                zip.write(fis.read)
-              // close the entry which was just written
-              zip.closeEntry
-            } catch {
-              case e: ZipException =>
-                //logger.error("unable to add entry "
-                //  + file.getName + " to zipn archive for paper "
-                //  + paperId + ". Skipping it...", e)
+          for(os <- managed(new ByteArrayOutputStream);
+              zip <- managed(new ZipOutputStream(os))) {
+            for (file <- toZip) {
+              for(fis <- managed(new FileInputStream(file))) {
+                try {
+                  // create a new entry
+                  zip.putNextEntry(new ZipEntry(file.getName))
+                  // write into this entry
+                  val length = fis.available
+                  for (i <- 0 until length)
+                    zip.write(fis.read)
+                  // close the entry which was just written
+                  zip.closeEntry
+                } catch {
+                  case e: ZipException =>
+                }
+              }
             }
+
+            zip.finish
+
+            talk.setContentType(HMime.zip)
+              .setContentLength(os.size)
+              .setFilename(s"$name.$format")
+              .write(os.toByteArray)
           }
-        }
 
-        zip.finish
+        case None =>
 
-        talk.setContentType(HMime.zip)
-          .setContentLength(os.size)
-          .write(os.toByteArray)
+          talk
+            .setStatus(HStatus.NotFound)
+            .writeJson(ErrorResponse("not_found", s"No paper data for paper $paperId"))
       }
 
     case _ =>
-      talk
+      Try(talk
         .setStatus(HStatus.Forbidden)
-        .writeJson(ErrorResponse("no_sufficient_rights", "Only authors may backup the paper sources"))
-  })
+        .writeJson(ErrorResponse("no_sufficient_rights", "Only authors may backup the paper sources")))
+  }
 
 }


### PR DESCRIPTION
There exists a special header named `Content-Disposition` that allows
for suggesting a filename to the web browser when it downloads a
resource.
It is a good idea to use it for files when the URL does not suggest any
user-friendly file name.
