### PR TITLE
Disallow inclusion of files from other papers

### DIFF
--- a/blue-common/src/main/scala/gnieh/blue/common/ConfigurationLoader.scala
+++ b/blue-common/src/main/scala/gnieh/blue/common/ConfigurationLoader.scala
@@ -20,13 +20,18 @@ import com.typesafe.config.Config
 
 import org.osgi.framework.Bundle
 
+import java.io.File
+
 /** Service that allows bundle to load the configuration of a module given its identifier
  *
  *  @author Lucas Satabin
  */
 trait ConfigurationLoader {
 
-  /** Load the configuration associated to the given module */
+  /** Load the configuration associated to the given bundle */
   def load(bundle: Bundle): Config
+
+  /** Returns the base configuration directory */
+   val base: File
 
 }

--- a/blue-common/src/main/scala/gnieh/blue/common/impl/ConfigurationLoaderImpl.scala
+++ b/blue-common/src/main/scala/gnieh/blue/common/impl/ConfigurationLoaderImpl.scala
@@ -34,7 +34,7 @@ import scala.collection.JavaConverters._
 
 import scala.annotation.tailrec
 
-class ConfigurationLoaderImpl(commonName: String, base: File) extends ConfigurationLoader {
+class ConfigurationLoaderImpl(commonName: String, val base: File) extends ConfigurationLoader {
 
   import FileUtils._
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/SystemCompiler.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/SystemCompiler.scala
@@ -39,7 +39,7 @@ import scala.sys.process._
  *
  *  @author Lucas Satabin
  */
-abstract class SystemCompiler(system: ActorSystem, config: Config) extends Compiler {
+abstract class SystemCompiler(system: ActorSystem, config: Config, texmfcnf: File) extends Compiler {
 
   val configuration = new PaperConfiguration(config)
 
@@ -48,7 +48,7 @@ abstract class SystemCompiler(system: ActorSystem, config: Config) extends Compi
   protected def exec(command: String, workingDir: File, env: List[(String, String)] = List())(implicit timeout: Timeout) =
     Try {
       Await.result(
-        systemCommand ? SystemCommand(command, workingDir, env, timeout) mapTo manifest[Int],
+        systemCommand ? SystemCommand(command, workingDir, ("TEXMFCNF" -> s"${texmfcnf.getCanonicalPath}:") :: env, timeout) mapTo manifest[Int],
         timeout.duration
       ) == 0
     }
@@ -68,7 +68,7 @@ abstract class SystemCompiler(system: ActorSystem, config: Config) extends Compi
   }
 
   protected def buildDir(paperId: String) = configuration.buildDir(paperId).getCanonicalPath
-  protected def paperFile(paperId: String) = configuration.paperFile(paperId).getCanonicalPath
+  protected def paperFile(paperId: String) = configuration.paperFile(paperId).getName
 
 }
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/CompilationActivator.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/CompilationActivator.scala
@@ -96,10 +96,10 @@ class CompilationActivator extends BundleActivator {
         context.registerService(classOf[PaperCreated], new CreateSettingsHook(config, logger), null)
 
       // register the compiler services
-      registerCompiler(context, new PdflatexCompiler(system, config))
-      registerCompiler(context, new LatexCompiler(system, config))
-      registerCompiler(context, new XelatexCompiler(system, config))
-      registerCompiler(context, new LualatexCompiler(system, config))
+      registerCompiler(context, new PdflatexCompiler(system, config, loader.base))
+      registerCompiler(context, new LatexCompiler(system, config, loader.base))
+      registerCompiler(context, new XelatexCompiler(system, config, loader.base))
+      registerCompiler(context, new LualatexCompiler(system, config, loader.base))
 
     }
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/compiler/LatexCompiler.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/compiler/LatexCompiler.scala
@@ -35,7 +35,7 @@ import com.typesafe.config.Config
  *
  *  @author Lucas Satabin
  */
-class LatexCompiler(system: ActorSystem, config: Config) extends SystemCompiler(system, config) {
+class LatexCompiler(system: ActorSystem, config: Config, configDir: File) extends SystemCompiler(system, config, configDir) {
 
   val name: String = "latex"
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/compiler/LualatexCompiler.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/compiler/LualatexCompiler.scala
@@ -35,7 +35,7 @@ import com.typesafe.config.Config
  *
  *  @author Lucas Satabin
  */
-class LualatexCompiler(system: ActorSystem, config: Config) extends SystemCompiler(system, config) {
+class LualatexCompiler(system: ActorSystem, config: Config, configDir: File) extends SystemCompiler(system, config, configDir) {
 
   val name: String = "lualatex"
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/compiler/PdflatexCompiler.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/compiler/PdflatexCompiler.scala
@@ -35,7 +35,7 @@ import com.typesafe.config.Config
  *
  *  @author Lucas Satabin
  */
-class PdflatexCompiler(system: ActorSystem, config: Config) extends SystemCompiler(system, config) {
+class PdflatexCompiler(system: ActorSystem, config: Config, configDir: File) extends SystemCompiler(system, config, configDir) {
 
   val name: String = "pdflatex"
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/compiler/XelatexCompiler.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/compiler/XelatexCompiler.scala
@@ -35,7 +35,7 @@ import com.typesafe.config.Config
  *
  *  @author Lucas Satabin
  */
-class XelatexCompiler(system: ActorSystem, config: Config) extends SystemCompiler(system, config) {
+class XelatexCompiler(system: ActorSystem, config: Config, configDir: File) extends SystemCompiler(system, config, configDir) {
 
   val name: String = "xelatex"
 

--- a/src/main/configuration/texmf.cnf
+++ b/src/main/configuration/texmf.cnf
@@ -1,0 +1,3 @@
+% disallow opening any file starting with a `.' and any file in
+% a path going up into the parent directory.
+openin_any = p


### PR DESCRIPTION
Make the file opening policy of the system compilers of texlive
prevents TeX from reading hidden files ( starting with a `.`) and paths
that, at some point, go to the parent directory.

The \BlueLaTeX custom texmf.cnf file prevents people from including
content from other papers (more precisely from other users' papers!)
and thus helps to avoid data leaks.

The paper will not compile if it contains somehting like:

``` tex
  \input{../some-paper/main.tex}
```

or

``` tex
  \include{./../some-other-paper/main.tex}
```

TeX documents are only allowed to include files present in the paper
directory or at standard TeX places on the system (system styles,
classes, ...).
