### PR TITLE
[fix #124] Make default API prefix relative

### DIFF
--- a/blue-common/src/main/resources/application.conf
+++ b/blue-common/src/main/resources/application.conf
@@ -48,7 +48,11 @@ blue {
 
     # the prefix of this \BlueLaTeX installation
     # if it is installed at the root of the domain, then leave this string empty
-    path-prefix = "/api"
+    # if the prefix is absolute (i.e. starting with a `/`) then the API is expected to
+    # be at the root of the virtual host.
+    # if the path is relative (i.e. not starting with `/`) then the client
+    # is expected to send its requests by appending its own prefix to the API prefix if it has any.
+    path-prefix = "api"
 
   }
 


### PR DESCRIPTION
When using \BlueLaTeX from behind a proxy, if the API prefix is
absolute, then it might lead to some problems because the client send
the request to `/api`.
This is a problem iF \BlueLaTeX is not accessed at the root before
the proxy rewrites the URL.
