### PR TITLE
Fix template bibliography stub

### DIFF
--- a/src/main/templates/generic.tex.mustache
+++ b/src/main/templates/generic.tex.mustache
@@ -25,6 +25,7 @@ Some text
 
 \section{Second Section}
 
-% to add the bibliography, uncomment the following line
-%\bibliography{references}
+% to add the bibliography, uncomment the following lines
+%\bibliography{references}{}
+%\bibliographystyle{plain}
 \end{document}


### PR DESCRIPTION
The default line to include bibliography must be correct to avoid making
people think it does not work with BibTeX.
