### PR TITLE
[fix #134] Remind username and email

### DIFF
--- a/src/main/templates/emails/register.mustache
+++ b/src/main/templates/emails/register.mustache
@@ -1,6 +1,9 @@
 Hi {{firstName}},
 
-You just registered to the \Blue service.
+You just registered to the \BlueLaTeX service.
+
+Your login is: {{name}}
+Your registration email address is: {{email}}
 
 To activate your account and set your password, please follow this link:
 {{baseUrl}}/index.html#/{{name}}/reset/{{token}}
@@ -9,6 +12,6 @@ This link is valid during {{validity}} days.
 
 If you did not register to the \Blue service, you can just ignore this email.
 
-Thank you for using \Blue
+Thank you for using \BlueLaTeX
 
-Your \Blue team
+Your \BlueLaTeX team

--- a/src/main/templates/emails/reset.mustache
+++ b/src/main/templates/emails/reset.mustache
@@ -1,6 +1,6 @@
 Hi,
 
-We received a password reset request for your account.
+We received a password reset request for your account {{name}}.
 
 To actually change your password, please follow this link:
 {{baseUrl}}/index.html#/{{name}}/reset/{{token}}
@@ -9,6 +9,6 @@ This link is valid during {{validity}} days.
 
 If you did not request a password reset, you can just ignore this email.
 
-Thank you for using \Blue
+Thank you for using \BlueLaTeX
 
-Your \Blue team
+Your \BlueLaTeX team


### PR DESCRIPTION
When a user registers to \BlueLaTeX, a validation email is sent with
instructions to set the password.

Reminding about the chosen username and email address might be good even
if the user receives the mail at the registered address, and the
username appears in the validation link.

Explicit stuffs are always better than implicit ones.

Closes #134 
