### PR TITLE
[fix #133] Better logging on module startup

### DIFF
--- a/blue-common/src/main/scala/gnieh/blue/common/impl/BlueCommonActivator.scala
+++ b/blue-common/src/main/scala/gnieh/blue/common/impl/BlueCommonActivator.scala
@@ -75,7 +75,7 @@ class BlueCommonActivator extends ActorSystemActivator {
     }
     context.registerService(classOf[LogService].getName, new LogServiceFactory, null)
 
-    for(logger <- context.get[Logger]) {
+    for(logger <- context.get[Logger]) try {
       val config = loader.load(context.getBundle)
 
       // register the couch client service
@@ -120,6 +120,10 @@ class BlueCommonActivator extends ActorSystemActivator {
       }
       context.registerService(classOf[Templates], templates.get, null)
 
+    } catch {
+      case e: Exception =>
+        logger.log(LogService.LOG_ERROR, s"Unable to start the core bundle", e)
+        throw e
     }
 
     // register the actor system as service so that other bundle can use it

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/CompilationActivator.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/CompilationActivator.scala
@@ -63,7 +63,7 @@ class CompilationActivator extends BundleActivator {
       system <- context.get[ActorSystem]
       couch <- context.get[CouchClient]
       logger <- context.get[LogService]
-    } {
+    } try {
       val config = loader.load(context.getBundle)
 
       // create the dispatcher actor
@@ -101,6 +101,10 @@ class CompilationActivator extends BundleActivator {
       registerCompiler(context, new XelatexCompiler(system, config, loader.base))
       registerCompiler(context, new LualatexCompiler(system, config, loader.base))
 
+    } catch {
+      case e: Exception =>
+        logger.log(LogService.LOG_ERROR, s"Unable to start the compilation bundle", e)
+        throw e
     }
 
   def registerCompiler(context: BundleContext, compiler: Compiler): Unit = {

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/BlueCoreActivator.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/BlueCoreActivator.scala
@@ -20,6 +20,7 @@ package impl
 import java.io.File
 
 import org.osgi.framework._
+import org.osgi.service.log.LogService
 
 import com.typesafe.config._
 
@@ -49,13 +50,17 @@ class BlueCoreActivator extends BundleActivator {
       templates <- context.get[Templates]
       mailAgent <- context.get[MailAgent]
       recaptcha <- context.get[ReCaptcha]
-    } {
+    } try {
       // load the \BlueLaTeX common configuration
       val config = loader.load(context.getBundle)
       val configuration = new BlueConfiguration(config)
 
       // register the core Rest API
       context.registerService(classOf[RestApi], new CoreApi(couch, config, system, context, templates, mailAgent, recaptcha, logger), null)
+    } catch {
+      case e: Exception =>
+        logger.log(LogService.LOG_ERROR, s"Unable to start the core bundle", e)
+        throw e
     }
 
   def stop(context: BundleContext): Unit = {

--- a/blue-sync/src/main/scala/gnieh/blue/sync/impl/SyncServerActivator.scala
+++ b/blue-sync/src/main/scala/gnieh/blue/sync/impl/SyncServerActivator.scala
@@ -43,7 +43,7 @@ class SyncServerActivator extends BundleActivator {
       system <- context.get[ActorSystem]
       couch <- context.get[CouchClient]
       logger <- context.get[LogService]
-    } {
+    } try {
       val config = loader.load(context.getBundle)
       // create the dispatcher actor
       val dispatcher = system.actorOf(Props(new SyncDispatcher(context, config, logger)), name = "sync-dispatcher")
@@ -55,6 +55,10 @@ class SyncServerActivator extends BundleActivator {
 
       //register the Rest API
       context.registerService(classOf[RestApi], new SyncApi(couch, config, server, logger), null)
+    } catch {
+      case e: Exception =>
+        logger.log(LogService.LOG_ERROR, s"Unable to start the synchronization bundle", e)
+        throw e
     }
 
   def stop(context: BundleContext): Unit =

--- a/blue-web/src/main/scala/gnieh/blue/web/BlueWebActivator.scala
+++ b/blue-web/src/main/scala/gnieh/blue/web/BlueWebActivator.scala
@@ -17,6 +17,7 @@ package gnieh.blue
 package web
 
 import org.osgi.framework._
+import org.osgi.service.log.LogService
 
 import tiscaf._
 
@@ -36,10 +37,17 @@ class BlueWebActivator extends BundleActivator {
   import OsgiUtils._
 
   def start(context: BundleContext): Unit =
-    for(loader <- context.get[ConfigurationLoader]) {
+    for {
+      loader <- context.get[ConfigurationLoader]
+      logger <- context.get[LogService]
+    } try {
       val config = loader.load(context.getBundle)
       // register the web application
       context.registerService(classOf[HApp], new WebApp(context, config), null)
+    } catch {
+      case e: Exception =>
+        logger.log(LogService.LOG_ERROR, s"Unable to start the web client bundle", e)
+        throw e
     }
 
   def stop(context: BundleContext): Unit = {


### PR DESCRIPTION
As soon as the logger gets created in the common bundle and in all other
bundle activators, we log exceptions in the log file.

Closes #133
