### PR TITLE
[fix #156] Fix regression in paper option

### DIFF
--- a/blue-web/src/main/resources/webapp/js/paper/controllers/EditPaperController.js
+++ b/blue-web/src/main/resources/webapp/js/paper/controllers/EditPaperController.js
@@ -240,7 +240,7 @@ angular.module('bluelatex.Paper.Controllers.EditPaper', ['bluelatex.Paper.Servic
           }
         });
 
-        var promiseRoles = $scope.modifyPaperRole;
+        var promiseRoles = $scope.modifyPaperRole();
         var promiseCompiler = modifyCompiler();
 
         promises.push(promisePaper);


### PR DESCRIPTION
The fix is quite simple, the problem is real however. The role saving
function must be actually executed for the roles to be persisted into
the database.

This bug only impacts the paper options screen, contributors can still
be added or removed by using the new "Share" menu in the paper editor.

Closes #156 
