### PR TITLE
[fix #175] Fix configuration keys in client

### DIFF
--- a/blue-web/src/main/resources/webapp/js/user/controllers/ProfileController.js
+++ b/blue-web/src/main/resources/webapp/js/user/controllers/ProfileController.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
  
-angular.module("bluelatex.User.Controllers.Profile",['bluelatex.User.Services.User'])
+angular.module("bluelatex.User.Controllers.Profile",['bluelatex.User.Services.User','reCAPTCHA'])
   .controller('ProfileController', [
     '$rootScope',
     '$scope',
@@ -23,6 +23,7 @@ angular.module("bluelatex.User.Controllers.Profile",['bluelatex.User.Services.Us
     '$log',
     'MessagesService',
     'localize',
+    'reCAPTCHA',
     'config',
     function ($rootScope,
               $scope,
@@ -31,6 +32,7 @@ angular.module("bluelatex.User.Controllers.Profile",['bluelatex.User.Services.Us
               $log,
               MessagesService,
               localize,
+              reCAPTCHA,
               config) {
       $scope.requesting = false;
       var user;
@@ -39,8 +41,8 @@ angular.module("bluelatex.User.Controllers.Profile",['bluelatex.User.Services.Us
          theme: 'clean'
       });
 
-      $scope.displayCaptcha = cofig.recaptcha_public_key != null;
-      reCAPTCHA.setPublicKey(cofig.recaptcha_public_key);
+      $scope.displayCaptcha = config.recaptcha_public_key != null;
+      reCAPTCHA.setPublicKey(config.recaptcha_public_key);
 
       /**
       * Get the user data

--- a/blue-web/src/main/resources/webapp/js/user/controllers/RegisterController.js
+++ b/blue-web/src/main/resources/webapp/js/user/controllers/RegisterController.js
@@ -40,7 +40,7 @@ angular.module("bluelatex.User.Controllers.Register",['bluelatex.User.Services.U
       MessagesService.message('_Registration_Password_will_sent_in_email_');
       $scope.displayCaptcha = config.recaptcha_public_key != null;
       reCAPTCHA.setPublicKey(config.recaptcha_public_key);
-      
+
       /**
       * Create a new user
       */

--- a/blue-web/src/main/resources/webapp/partials/menu.html
+++ b/blue-web/src/main/resources/webapp/partials/menu.html
@@ -13,11 +13,11 @@
       </div>
     </div>
     <div id="git">
-      <a ng-href="config.clone-url" target="_blank" ng-if="config.clone-url">
+      <a ng-href="{{config.clone_url}}" target="_blank" ng-if="config.clone_url">
         <span class="icon icon-fork"></span>
         <span data-i18n="_Clone_me_"></span>
       </a> 
-      <a ng-href="config.issues-url" target="_blank" ng-if="config.issues-url">
+      <a ng-href="{{config.issues_url}}" target="_blank" ng-if="config.issues_url">
         <span class="icon icon-exclamation"></span>
         <span data-i18n="_Report_an_issue_"></span>
       </a>


### PR DESCRIPTION
The client must read the correct configuration keys for clone and issue
URLs, which are respectively `clone_url` and `issues_url` separated with
underscores.
Moreover, the reCAPTCHA element must be imported wherever it is used.
