### PR TITLE
[imp #168] Reload pdf on non critical errors

### DIFF
--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/BackgroundCompilationActor.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/BackgroundCompilationActor.scala
@@ -106,6 +106,10 @@ class BackgroundCompilationActor(
         couch <- bndContext.get[CouchClient]
       } {
 
+        val pdfFile = paperConfig.buildDir(paperId) / s"main.pdf"
+
+        val lastPdfModification = pdfFile.lastModified
+
         // TODO ideally the number of times we run the latex compiler, and bibtex,
         // and the index compiler should be smarter than this.
         // For the moment, we run only once, but we could make it configurable if the compilation
@@ -122,10 +126,12 @@ class BackgroundCompilationActor(
           for(file <- paperConfig.buildDir(paperId).filter(_.extension == ".png"))
             file.delete
 
+          val newPdfModification = pdfFile.lastModified
+
           if(res)
             CompilationSucceeded
           else
-            CompilationFailed
+            CompilationFailed(newPdfModification > lastPdfModification)
 
         }
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/CompilationStatus.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/CompilationStatus.scala
@@ -21,7 +21,7 @@ sealed trait CompilationStatus
 
 case object CompilationSucceeded extends CompilationStatus
 
-case object CompilationFailed extends CompilationStatus
+final case class CompilationFailed(pdfProduced: Boolean) extends CompilationStatus
 
 case object CompilationAborted extends CompilationStatus
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/ExplicitCompilationActor.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/ExplicitCompilationActor.scala
@@ -105,6 +105,10 @@ class ExplicitCompilationActor(
         couch <- bndContext.get[CouchClient]
       } {
 
+        val pdfFile = paperConfig.buildDir(paperId) / s"main.pdf"
+
+        val lastPdfModification = pdfFile.lastModified
+
         // TODO ideally the number of times we run the latex compiler, and bibtex,
         // and the index compiler should be smarter than this.
         // For the moment, we run only once, but we could make it configurable if the compilation
@@ -121,10 +125,12 @@ class ExplicitCompilationActor(
           for(file <- paperConfig.buildDir(paperId).filter(_.extension == ".png"))
             file.delete
 
+          val newPdfModification = pdfFile.lastModified
+
           if(res)
             CompilationSucceeded
           else
-            CompilationFailed
+            CompilationFailed(newPdfModification > lastPdfModification)
 
         }
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/CompilerLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/CompilerLet.scala
@@ -43,9 +43,9 @@ class CompilerLet(paperId: String, val couch: CouchClient, dispatcher: ActorRef,
       dispatcher ! Forward(paperId, Register(user.name, promise))
 
       promise.future.map {
-        case CompilationSucceeded =>
+        case CompilationSucceeded | CompilationFailed(true) =>
           talk.writeJson(true)
-        case CompilationFailed =>
+        case CompilationFailed(false) =>
           talk
             .setStatus(HStatus.InternalServerError)
             .writeJson(ErrorResponse("unable_to_compile", "Compilation failed, more details in the compilation log file."))


### PR DESCRIPTION
Sometimes, the compilation of a document with \LaTeX produces some
errors, but a pdf file is still generated.
In such cases, the web client now loads the new pdf file, while still
indicating errors.
If no pdf file was produced, nothing changes.
