### PR TITLE
[imp #173] Add button to cleanup files

### DIFF
--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/BackgroundCompilationActor.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/BackgroundCompilationActor.scala
@@ -91,7 +91,8 @@ class BackgroundCompilationActor(
       val lastModificationDate = synchro.lastModificationDate(paperId)
 
       // create the build directory
-      paperConfig.buildDir(paperId).mkdirs
+      val buildDir = paperConfig.buildDir(paperId)
+      buildDir.mkdirs
 
       // Check if compilation is needed:
       // No need to recompile document if it has not been modified,
@@ -112,7 +113,7 @@ class BackgroundCompilationActor(
         // occurs on its own compilation server
         // it is also not necessary to run bibtex if no bibliography is to be generated
         // the settings should be able to handle this properly
-        val res = if (!hasBeenModified) Success(CompilationUnnecessary) else for {
+        val res = if (!hasBeenModified && (buildDir / "main.aux").exists) Success(CompilationUnnecessary) else for {
           // if the compiler is defined, we first compile the paper
           res <- compiler.compile(paperId, settings)
           // we run bibtex on it if the compilation succeeded

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/ExplicitCompilationActor.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/ExplicitCompilationActor.scala
@@ -90,7 +90,8 @@ class ExplicitCompilationActor(
       val lastModificationDate = synchro.lastModificationDate(paperId)
 
       // create the build directory
-      paperConfig.buildDir(paperId).mkdirs
+      val buildDir = paperConfig.buildDir(paperId)
+      buildDir.mkdirs
 
       // Check if compilation is needed:
       // No need to recompile document if it has not been modified,
@@ -111,7 +112,7 @@ class ExplicitCompilationActor(
         // occurs on its own compilation server
         // it is also not necessary to run bibtex if no bibliography is to be generated
         // the settings should be able to handle this properly
-        val res = if (!hasBeenModified) Success(CompilationUnnecessary) else for {
+        val res = if (!hasBeenModified && (buildDir / "main.aux").exists) Success(CompilationUnnecessary) else for {
           // if the compiler is defined, we first compile the paper
           res <- compiler.compile(paperId, settings)
           // we run bibtex on it if the compilation succeeded

--- a/blue-web/src/main/assets/less/paper.less
+++ b/blue-web/src/main/assets/less/paper.less
@@ -358,6 +358,24 @@
     background: rgba(255,0,0,0.13);
     z-index: 0;
 }
+.option {
+    .label {
+        &.process{
+            margin-right: 25px;
+        }
+        &.process::after {
+            position: absolute;
+            display: block;
+            content: "";
+            background-image: url("@{url_images}/spin.gif");
+            background-repeat: no-repeat;
+            width: 16px;
+            height: 16px;
+            top: 11px;
+            right: -25px;
+        }
+    }
+}
 .subOption {
     position: relative;
     height: 100%;

--- a/blue-web/src/main/resources/webapp/i18n/resources-locale_default.js
+++ b/blue-web/src/main/resources/webapp/i18n/resources-locale_default.js
@@ -564,6 +564,16 @@
         "description":"Download"
     },
     {
+        "key":"_Cleanup_",
+        "value":"Cleanup",
+        "description":"Cleanup"
+    },
+    {
+        "key":"_Compilation_dir_cleaned_up_",
+        "value":"Compilation directory cleaned up",
+        "description":"Cleaned up"
+    },
+    {
         "key":"_Share_",
         "value":"Share",
         "description":"Share"
@@ -942,7 +952,12 @@
         "description":"tooltip paper page: compile"
     },
     {
-        "key":"_Share_tooltip_",
+        "key":"_cleanup_tooltip_",
+        "value":"Cleanup the compilation directory.",
+        "description":"tooltip paper page: cleanup"
+    },
+    {
+        "key":"_share_tooltip_",
         "value":"Manage paper permissions",
         "description":"tooltip share"
     },

--- a/blue-web/src/main/resources/webapp/i18n/resources-locale_fr.js
+++ b/blue-web/src/main/resources/webapp/i18n/resources-locale_fr.js
@@ -554,6 +554,16 @@
         "description":"Compiler"
     },
     {
+        "key":"_Cleanup_",
+        "value":"Nettoyer",
+        "description":"Cleanup"
+    },
+    {
+        "key":"_Compilation_dir_cleaned_up_",
+        "value":"Répertoire de compilation nettoyé",
+        "description":"Cleaned up"
+    },
+    {
         "key":"_Download_",
         "value":"Télécharger",
         "description":"Download"
@@ -932,7 +942,12 @@
         "description":"tooltip paper page: compile"
     },
     {
-        "key":"_Share_tooltip_",
+        "key":"_cleanup_tooltip_",
+        "value":"Nettoyer le répertoire de compilation.",
+        "description":"tooltip paper page: cleanup"
+    },
+    {
+        "key":"_share_tooltip_",
         "value":"Gérer les permissions de l'article",
         "description":"tooltip share"
     },

--- a/blue-web/src/main/resources/webapp/js/paper/controllers/LatexPaperController.js
+++ b/blue-web/src/main/resources/webapp/js/paper/controllers/LatexPaperController.js
@@ -651,6 +651,16 @@ angular.module('bluelatex.Paper.Controllers.LatexPaper', [
         return deferred.promise;
       };
 
+      /*********************************/
+      /* Cleanup compilation directory */
+      /*********************************/
+      $scope.cleanup = function() {
+        $scope.cleanupInProgress = true;
+        PaperService.cleanupPaper($scope.paperId).finally(function() {
+          $scope.cleanupInProgress = false;
+        });
+      };
+
       /*****************/
       /* It's all text */ 
       /*****************/
@@ -729,7 +739,7 @@ angular.module('bluelatex.Paper.Controllers.LatexPaper', [
       $scope.cancelShare = function () {
         ngDialog.close();
       };
-      
+
 
       /**
       * Load ACE editor

--- a/blue-web/src/main/resources/webapp/js/paper/services/PaperService.js
+++ b/blue-web/src/main/resources/webapp/js/paper/services/PaperService.js
@@ -107,6 +107,16 @@ angular.module('bluelatex.Paper.Services.Paper', ["ngResource",'angular-data.DSC
             }
           ].concat($http.defaults.transformResponse)
         },
+        // cleanup compilation directory
+        "cleanup": {
+          method: "delete",
+          transformResponse: [
+            function (data, headersGetter) {
+              data = JSON.parse(data);
+              return data;
+            }
+          ].concat($http.defaults.transformResponse)
+        },
         // change compiler settings
         "modify": {
           method: "PATCH",
@@ -556,6 +566,18 @@ angular.module('bluelatex.Paper.Services.Paper', ["ngResource",'angular-data.DSC
               deferred.notify(progress);
             });
           }
+          return promise;
+        },
+        cleanupPaper: function(paper_id) {
+          var deferred = $q.defer();
+          var promise = deferred.promise;
+          compiler.cleanup({paper_id: paper_id},{}).$promise.then(function (data) {
+            deferred.resolve(data);
+          }, function (error) {
+            deferred.reject(error);
+          }, function (progress) {
+            deferred.notify(progress);
+          });
           return promise;
         },
         getPaperCompiler: function (paper_id) {

--- a/blue-web/src/main/resources/webapp/partials/paper/latex/author.html
+++ b/blue-web/src/main/resources/webapp/partials/paper/latex/author.html
@@ -42,6 +42,11 @@
 			</div>
 		  </div>
 		</div>
+		<div class="option">
+			<div class="label" ng-class="{'process': cleanupInProgress}">
+				<span ng-click="cleanup()" data-i18n="_Cleanup_" i18n-Tooltip="_cleanup_tooltip_"></span>
+			</div>
+		</div>
 		<div class="subOption">
 		  <div class="label">
 			<span ng-click="downloadPDF()" data-i18n="_Download_" i18n-Tooltip="_download_pdf_tooltip_"></span>


### PR DESCRIPTION
Sometimes, we need to explicitly clean files in the compilation
directory. The server has supported this for a long time now, without
being exposed in the web client.
That is now the case.

I also used this chance to improve the recompilation after a cleanup. If
the .aux file cannot be found, the compilation is performed, even if the
paper did not change. This makes sense, because if the user cleaned up
the compilation directory, it probably means that he wants a fresh
compilation to be performed.
