### PR TITLE
[add #181] Preserves the cursor position between files

### DIFF
--- a/blue-web/src/main/resources/webapp/js/paper/controllers/LatexPaperController.js
+++ b/blue-web/src/main/resources/webapp/js/paper/controllers/LatexPaperController.js
@@ -120,6 +120,9 @@ angular.module('bluelatex.Paper.Controllers.LatexPaper', [
       $scope.pdf = null;
       $scope.revision=Math.random();
 
+      // save the laste cursor position per file
+      var cursorPositionFile = {};
+
       /**************/
       /* Exit Paper */
       /**************/
@@ -487,6 +490,7 @@ angular.module('bluelatex.Paper.Controllers.LatexPaper', [
       */
       $scope.changeFile = function (file, line) {
         var deferred = $q.defer();
+        cursorPositionFile[$scope.currentFile.title] = MobWriteService.shared[$scope.currentFile.title].captureCursor_();
         if($scope.currentFile == file) return;
         MobWriteService.unshare({paper_id: $scope.paperId,file:$scope.currentFile.title}).then(function(data) {
           $scope.currentFile = file;
@@ -497,6 +501,8 @@ angular.module('bluelatex.Paper.Controllers.LatexPaper', [
           initMobWrite().then(function (data) {
             if(line) {
               $scope.goToLine(line);
+            } else if(cursorPositionFile[file.title] != null) {
+              MobWriteService.shared[$scope.currentFile.title].restoreCursor_(cursorPositionFile[file.title]);
             }
             deferred.resolve(data);
           }, function(err) {
@@ -549,8 +555,8 @@ angular.module('bluelatex.Paper.Controllers.LatexPaper', [
       /**
       * Go to the line: line
       */
-      $scope.goToLine = function (line) {
-        AceService.goToLine(line);
+      $scope.goToLine = function (line, column) {
+        AceService.goToLine(line, column);
         if(!$scope.synctex) return;
         if(!$scope.synctex.blockNumberLine[$scope.currentFile.title]) return;
         if(!$scope.synctex.blockNumberLine[$scope.currentFile.title][$scope.currentLine]) return;

--- a/blue-web/src/main/resources/webapp/js/paper/services/AceService.js
+++ b/blue-web/src/main/resources/webapp/js/paper/services/AceService.js
@@ -79,8 +79,8 @@ angular.module('bluelatex.Paper.Services.Ace', ['ngStorage','ui.ace'])
         _renderer.setShowGutter(aceSettings.showGutter);
       };
       // go to a specific line and give focus to ace
-      var goToLine = function (line) {
-        _editor.gotoLine(line);
+      var goToLine = function (line, column) {
+        _editor.gotoLine(line, column);
         _editor.focus();
       };
 

--- a/blue-web/src/main/resources/webapp/lib/angular-mobwrite.js
+++ b/blue-web/src/main/resources/webapp/lib/angular-mobwrite.js
@@ -870,6 +870,7 @@ angularMobwrite.factory("MobWriteService", ['$http', '$log', '$q','MobWriteConfi
     return {
       syncUsername: syncUsername,
       shareObj: shareObj,
+      shared: shared,
       synchronize: synchronize,
       share: share,
       unshare: unshare,


### PR DESCRIPTION
The cursor position is saved before switching between files when the user returns to the file the cursor position is restored.

This is not perfect, the cursor position can be altered if a co-author has changed the content of the file.
