### PR TITLE
[fix #171] Disable the key bindings for ctrl-l and crtl-t

### DIFF
--- a/blue-web/src/main/resources/webapp/js/paper/services/AceService.js
+++ b/blue-web/src/main/resources/webapp/js/paper/services/AceService.js
@@ -92,6 +92,12 @@ angular.module('bluelatex.Paper.Services.Ace', ['ngStorage','ui.ace'])
         _renderer = _editor.renderer;
         content = _session.getValue();
 
+        // disable key bindings
+        _editor.commands.bindKeys({
+          "ctrl-t":null,              // transpose letters
+          "ctrl-l":null, "cmd-l":null // go to line
+        });
+
         // add undo support
         _session.setUndoManager(new ace.UndoManager());
         _editor.setOptions({


### PR DESCRIPTION
Disables the ace key bindings ctrl-l and crtl-t, in order to reactivate the browser key bindings.
