### PR TITLE
Feature/better roles

### DIFF
--- a/blue-common/src/main/resources/application.conf
+++ b/blue-common/src/main/resources/application.conf
@@ -75,6 +75,7 @@ blue {
   # However permissions assigned to each role can be tuned for each paper.
   # The list of valid permissions is:
   #  - `edit` allows for collaboratively editing the paper,
+  #  - `delete` allows for deleting a paper,
   #  - `compile` allows for compiling the paper,
   #  - `configure` allows for configuring the paper settings like compiler settings for example (if any),
   #  - `publish` allows for using the publication feature (like creating a tag or sending to arXive),
@@ -85,6 +86,7 @@ blue {
   #  - `chat` allows for interacting with other connected users in the chat,
   #  - `fork` allows for creating a derivative of this paper,
   #  - `change-phase` allows for changing the current phase of the paper.
+  #  - any other string is a cutom permission that can be used in any module
   permissions {
 
     # Defines the basic permissions to assign to a private paper, this can be changed later
@@ -92,7 +94,7 @@ blue {
     # taken whenever a permission check is performed.
     private-defaults {
       # authors can do anything
-      author = [ edit, compile, configure, publish, download, read, view, comment, chat, fork, change-phase ]
+      author = [ edit, delete, compile, configure, publish, download, read, view, comment, chat, fork, change-phase ]
       # reviewers may read and comment
       reviewer = [ compile, view, comment ]
       # guests may only read
@@ -108,7 +110,7 @@ blue {
     # taken whenever a permission check is performed.
     public-defaults {
       # authors, reviewers, guest, other and anonymous can do anything
-      author = [ edit, compile, configure, publish, download, read, view, comment, chat, fork, change-phase ]
+      author = [ edit, delete, compile, configure, publish, download, read, view, comment, chat, fork, change-phase ]
       reviewer = ${blue.permissions.public-defaults.author}
       guests = ${blue.permissions.public-defaults.author}
       other = ${blue.permissions.public-defaults.author}

--- a/blue-common/src/main/resources/application.conf
+++ b/blue-common/src/main/resources/application.conf
@@ -112,7 +112,7 @@ blue {
       # authors, reviewers, guest, other and anonymous can do anything
       author = [ edit, delete, compile, configure, publish, download, read, view, comment, chat, fork, change-phase ]
       reviewer = ${blue.permissions.public-defaults.author}
-      guests = ${blue.permissions.public-defaults.author}
+      guest = ${blue.permissions.public-defaults.author}
       other = ${blue.permissions.public-defaults.author}
       anonymous = ${blue.permissions.public-defaults.author}
     }

--- a/blue-common/src/main/resources/application.conf
+++ b/blue-common/src/main/resources/application.conf
@@ -86,13 +86,13 @@ blue {
   #  - `chat` allows for interacting with other connected users in the chat,
   #  - `fork` allows for creating a derivative of this paper,
   #  - `change-phase` allows for changing the current phase of the paper.
-  #  - any other string is a cutom permission that can be used in any module
+  #  - any other string is a custom permission that can be used in any module
   permissions {
 
     # Defines the basic permissions to assign to a private paper, this can be changed later
     # in any existing paper. If no permission entity exists, these permission will be
     # taken whenever a permission check is performed.
-    private-defaults {
+    private {
       # authors can do anything
       author = [ edit, delete, compile, configure, publish, download, read, view, comment, chat, fork, change-phase ]
       # reviewers may read and comment
@@ -108,14 +108,25 @@ blue {
     # Defines the basic permissions to assign to a public paper, this can be changed later
     # in any existing paper. If no permission entity exists, these permission will be
     # taken whenever a permission check is performed.
-    public-defaults {
+    public {
       # authors, reviewers, guest, other and anonymous can do anything
       author = [ edit, delete, compile, configure, publish, download, read, view, comment, chat, fork, change-phase ]
-      reviewer = ${blue.permissions.public-defaults.author}
-      guest = ${blue.permissions.public-defaults.author}
-      other = ${blue.permissions.public-defaults.author}
-      anonymous = ${blue.permissions.public-defaults.author}
+      reviewer = ${blue.permissions.public.author}
+      guest = ${blue.permissions.public.author}
+      other = ${blue.permissions.public.author}
+      anonymous = ${blue.permissions.public.author}
     }
+
+    # You may add any default built-in permission set here.
+    # Any missing role is interpreted as the empty list of permissions
+    # e.g.
+    # my-useless-permissions {
+    #   author = []
+    #   reviewer = []
+    #   guest = []
+    #   other = []
+    #   anonymous = []
+    # }
 
   }
 

--- a/blue-common/src/main/scala/gnieh/blue/common/SetUtils.scala
+++ b/blue-common/src/main/scala/gnieh/blue/common/SetUtils.scala
@@ -25,10 +25,6 @@ object SingletonSet {
 }
 
 object EmptySet {
-  def unapply[T](set: Set[T]): Option[Unit] =
-    if(set.isEmpty)
-      Some()
-    else
-      None
+  def unapply[T](set: Set[T]): Boolean =
+    set.isEmpty
 }
-

--- a/blue-common/src/main/scala/gnieh/blue/common/impl/BlueCommonActivator.scala
+++ b/blue-common/src/main/scala/gnieh/blue/common/impl/BlueCommonActivator.scala
@@ -40,6 +40,7 @@ import com.typesafe.config._
 
 import gnieh.sohva.control.CouchClient
 import gnieh.sohva.control.entities.EntityManager
+import gnieh.sohva.JsonSerializer
 
 /** Register the configuration loader service that is used by everybody
  *
@@ -135,7 +136,7 @@ class BlueCommonActivator extends ActorSystemActivator {
     val port = config.getInt("couch.port")
     val ssl = config.getBoolean("couch.ssl")
     val timeout = Timeout(config.getDuration("couch.timeout", TimeUnit.SECONDS).seconds)
-    val c = new CouchClient(host = hostname, port = port, ssl = ssl)(system, timeout)
+    val c = new CouchClient(host = hostname, port = port, ssl = ssl, custom = List(BluePermissionSerializer))(system, timeout)
     couch = Some(c)
     c
   }

--- a/blue-common/src/main/scala/gnieh/blue/common/package.scala
+++ b/blue-common/src/main/scala/gnieh/blue/common/package.scala
@@ -15,13 +15,43 @@
  */
 package gnieh.blue
 
-import com.typesafe.config.Config
+import com.typesafe.config.{
+  Config,
+  ConfigValue
+}
+
+import scala.collection.JavaConverters._
+import scala.util.Try
 
 package object common {
 
   type Logger = org.osgi.service.log.LogService
 
   type UserInfo = gnieh.sohva.UserInfo
+
+  implicit class PermissionsConfig(val config: Config) extends AnyVal {
+
+    def getBuiltInPermissions: Map[String, Map[String, Set[String]]] =
+        if(config.hasPath("blue.permissions")) {
+          val permissions = config.getObject("blue.permissions")
+          Try {
+            for {
+              (name, _) <- permissions.asScala
+            } yield (name, toMap(permissions.toConfig().getConfig(name)))
+          } map (_.toMap) getOrElse(Map())
+        } else {
+          Map()
+        }
+
+  }
+
+  def toMap(value: Config): Map[String, Set[String]] =
+    Map(
+      "author" -> (if(value.hasPath("author")) value.getStringList("author").asScala.toSet else Set()),
+      "reviewer" -> (if(value.hasPath("reviewer")) value.getStringList("reviewer").asScala.toSet else Set()),
+      "guest" -> (if(value.hasPath("guest")) value.getStringList("guest").asScala.toSet else Set()),
+      "other" -> (if(value.hasPath("other")) value.getStringList("other").asScala.toSet else Set()),
+      "anonymous" -> (if(value.hasPath("anonymous")) value.getStringList("anonymous").asScala.toSet else Set()))
 
 }
 

--- a/blue-common/src/main/scala/gnieh/blue/couch/PaperPhase.scala
+++ b/blue-common/src/main/scala/gnieh/blue/couch/PaperPhase.scala
@@ -30,4 +30,4 @@ import permission.{
  *
  *  @author Lucas Satabin
  */
-case class PaperPhase(_id: String, phase: String, permissions: Map[Role, List[Permission]], next: Set[Phase]) extends IdRev
+case class PaperPhase(_id: String, phase: String, permissions: Map[String, List[Permission]], next: List[Phase]) extends IdRev

--- a/blue-common/src/main/scala/gnieh/blue/couch/UserPermissions.scala
+++ b/blue-common/src/main/scala/gnieh/blue/couch/UserPermissions.scala
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the \BlueLaTeX project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gnieh.blue.couch
+
+import gnieh.sohva._
+
+/** Users may define their own set of permissions and save them so
+ *  that he can reuse them later on.
+ *
+ *  @author Lucas Satabin
+ *
+ */
+case class UserPermissions(_id: String,
+                           permissions: Map[String, Map[String, Set[String]]]) extends IdRev

--- a/blue-common/src/main/scala/gnieh/blue/couch/impl/BlueSerializers.scala
+++ b/blue-common/src/main/scala/gnieh/blue/couch/impl/BlueSerializers.scala
@@ -1,0 +1,29 @@
+package gnieh.blue
+package couch
+package impl
+
+import net.liftweb.json._
+
+import gnieh.sohva.SohvaSerializer
+
+import permission._
+
+object PermissionSerializer extends Serializer[Permission] {
+
+  val PermissionClass = classOf[Permission]
+
+  def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), Permission] = {
+    case (TypeInfo(PermissionClass, _), JString(name)) =>
+      Permission(name)
+  }
+
+  def serialize(implicit format: Formats): PartialFunction[Any, JValue] = {
+    case Permission(name) => JString(name)
+  }
+
+}
+
+object BluePermissionSerializer extends SohvaSerializer[Permission] {
+  def serializer(v: String) =
+    PermissionSerializer
+}

--- a/blue-common/src/main/scala/gnieh/blue/permission/Permission.scala
+++ b/blue-common/src/main/scala/gnieh/blue/permission/Permission.scala
@@ -20,32 +20,45 @@ package permission
  *
  *  @author Lucas Satabin
  */
-sealed trait Permission
-case object Publish extends Permission
-case object Configure extends Permission
-case object Edit extends Permission
-case object Compile extends Permission
-case object Download extends Permission
-case object Read extends Permission
-case object Comment extends Permission
-case object Chat extends Permission
-case object Fork extends Permission
-case object ChangePhase extends Permission
+sealed abstract class Permission(val name: String) {
+  def unapply(permissions: List[Permission]): Boolean =
+    permissions.contains(this)
+}
+
+case object Publish extends Permission("publish")
+case object Configure extends Permission("configure")
+case object Edit extends Permission("edit")
+case object Delete extends Permission("delete")
+case object Compile extends Permission("compile")
+case object Download extends Permission("download")
+case object Read extends Permission("read")
+case object View extends Permission("view")
+case object Comment extends Permission("comment")
+case object Chat extends Permission("chat")
+case object Fork extends Permission("fork")
+case object ChangePhase extends Permission("change-phase")
+final case class Custom(override val name: String) extends Permission(name)
 
 object Permission {
 
-  def apply(name: String): Option[Permission] = name match {
-    case "publish"      => Some(Publish)
-    case "configure"    => Some(Configure)
-    case "edit"         => Some(Edit)
-    case "compile"      => Some(Compile)
-    case "download"     => Some(Download)
-    case "read"         => Some(Read)
-    case "comment"      => Some(Comment)
-    case "chat"         => Some(Chat)
-    case "fork"         => Some(Fork)
-    case "change-phase" => Some(ChangePhase)
-    case _              => None
+  def apply(name: String): Permission = name match {
+    case "publish"      => Publish
+    case "configure"    => Configure
+    case "edit"         => Edit
+    case "delete"       => Delete
+    case "compile"      => Compile
+    case "download"     => Download
+    case "read"         => Read
+    case "comment"      => Comment
+    case "chat"         => Chat
+    case "fork"         => Fork
+    case "change-phase" => ChangePhase
+    case _              => Custom(name)
+  }
+
+  def unapply(x: Any) = x match {
+    case p: Permission => Some(p.name)
+    case _             => None
   }
 
 }

--- a/blue-common/src/main/scala/gnieh/blue/permission/Permission.scala
+++ b/blue-common/src/main/scala/gnieh/blue/permission/Permission.scala
@@ -20,45 +20,7 @@ package permission
  *
  *  @author Lucas Satabin
  */
-sealed abstract class Permission(val name: String) {
-  def unapply(permissions: List[Permission]): Boolean =
+final case class Permission(val name: String) {
+  def unapply(permissions: Set[Permission]): Boolean =
     permissions.contains(this)
-}
-
-case object Publish extends Permission("publish")
-case object Configure extends Permission("configure")
-case object Edit extends Permission("edit")
-case object Delete extends Permission("delete")
-case object Compile extends Permission("compile")
-case object Download extends Permission("download")
-case object Read extends Permission("read")
-case object View extends Permission("view")
-case object Comment extends Permission("comment")
-case object Chat extends Permission("chat")
-case object Fork extends Permission("fork")
-case object ChangePhase extends Permission("change-phase")
-final case class Custom(override val name: String) extends Permission(name)
-
-object Permission {
-
-  def apply(name: String): Permission = name match {
-    case "publish"      => Publish
-    case "configure"    => Configure
-    case "edit"         => Edit
-    case "delete"       => Delete
-    case "compile"      => Compile
-    case "download"     => Download
-    case "read"         => Read
-    case "comment"      => Comment
-    case "chat"         => Chat
-    case "fork"         => Fork
-    case "change-phase" => ChangePhase
-    case _              => Custom(name)
-  }
-
-  def unapply(x: Any) = x match {
-    case p: Permission => Some(p.name)
-    case _             => None
-  }
-
 }

--- a/blue-common/src/main/scala/gnieh/blue/permission/package.scala
+++ b/blue-common/src/main/scala/gnieh/blue/permission/package.scala
@@ -14,20 +14,22 @@
  * limitations under the License.
  */
 package gnieh.blue
-package couch
 
-import gnieh.sohva.IdRev
+package object permission {
 
-import permission.{
-  Phase,
-  Role,
-  Permission
+  // some widely used 'built-in' permissions
+
+  val Publish = Permission("publish")
+  val Configure = Permission("configure")
+  val Edit = Permission("edit")
+  val Delete = Permission("delete")
+  val Compile = Permission("compile")
+  val Download = Permission("download")
+  val Read = Permission("read")
+  val View = Permission("view")
+  val Comment = Permission("comment")
+  val Chat = Permission("chat")
+  val Fork = Permission("fork")
+  val ChangePhase = Permission("change-phase")
+
 }
-
-/** Phase component that can be attached to a paper entity.
- *  It associates the current phase to a paper and the next allowed phases as well
- *  as the permissions for this phase.
- *
- *  @author Lucas Satabin
- */
-case class PaperPhase(_id: String, phase: String, permissions: Map[String, Set[Permission]], next: List[Phase]) extends IdRev

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/SystemCommandActor.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/SystemCommandActor.scala
@@ -34,7 +34,7 @@ import scala.sys.process.{
 }
 
 import scala.concurrent.{
-  future,
+  Future,
   Await
 }
 
@@ -64,7 +64,7 @@ class SystemCommandActor(val logger: Logger) extends Actor with Logging {
   private def exec(timeout: Timeout, process: ProcessBuilder) = {
 
     val proc = process.run(SystemProcessLogger)
-    val res = future {
+    val res = Future {
       proc.exitValue()
     }
     try {

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/CleanLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/CleanLet.scala
@@ -34,10 +34,10 @@ import gnieh.sohva.control.CouchClient
  *
  *  @author Lucas Satabin
  */
-class CleanLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncRoleLet(paperId, config, logger) {
+class CleanLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Any] = role match {
-    case Author =>
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+    case Edit() =>
 
       import FileUtils._
 
@@ -55,7 +55,7 @@ class CleanLet(paperId: String, val couch: CouchClient, config: Config, logger: 
       Try(
         talk
           .setStatus(HStatus.Forbidden)
-          .writeJson(ErrorResponse("no_sufficient_rights", "Only authors may clean compilation results")))
+          .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to clean compilation results")))
 
   }
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/CleanLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/CleanLet.scala
@@ -36,7 +36,7 @@ import gnieh.sohva.control.CouchClient
  */
 class CleanLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
     case Edit() =>
 
       import FileUtils._

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/CleanLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/CleanLet.scala
@@ -36,7 +36,7 @@ import gnieh.sohva.control.CouchClient
  */
 class CleanLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
     case Edit() =>
 
       import FileUtils._

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/CompilerLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/CompilerLet.scala
@@ -33,10 +33,10 @@ import com.typesafe.config.Config
 
 import gnieh.sohva.control.CouchClient
 
-class CompilerLet(paperId: String, val couch: CouchClient, dispatcher: ActorRef, config: Config, logger: Logger) extends AsyncRoleLet(paperId, config, logger) {
+class CompilerLet(paperId: String, val couch: CouchClient, dispatcher: ActorRef, config: Config, logger: Logger) extends AsyncPermissionLet(paperId, config, logger) {
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Future[Any] = role match {
-    case Author =>
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Future[Any] = permissions match {
+    case Compile() =>
       val promise = Promise[CompilationStatus]()
 
       // register the client with the paper compiler
@@ -65,11 +65,11 @@ class CompilerLet(paperId: String, val couch: CouchClient, dispatcher: ActorRef,
             .writeJson(ErrorResponse("unable_to_compile", "Compilation failed, more details in the compilation log file."))
       }
 
-    case Reviewer | Other =>
+    case _ =>
       Future.successful(
         talk
           .setStatus(HStatus.Forbidden)
-          .writeJson(ErrorResponse("no_sufficient_rights", "Only authors may compile a paper")))
+          .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to compile the paper")))
 
   }
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/CompilerLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/CompilerLet.scala
@@ -35,34 +35,41 @@ import gnieh.sohva.control.CouchClient
 
 class CompilerLet(paperId: String, val couch: CouchClient, dispatcher: ActorRef, config: Config, logger: Logger) extends AsyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Future[Any] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Future[Any] = permissions match {
     case Compile() =>
       val promise = Promise[CompilationStatus]()
 
       // register the client with the paper compiler
-      dispatcher ! Forward(paperId, Register(user.name, promise))
+      user.map(_.name).orElse(talk.req.param("name")) match {
+        case Some(name) =>
+          dispatcher ! Forward(paperId, Register(name, promise))
 
-      promise.future.map {
-        case CompilationSucceeded | CompilationFailed(true) =>
-          talk.writeJson(true)
-        case CompilationFailed(false) =>
-          talk
-            .setStatus(HStatus.InternalServerError)
-            .writeJson(ErrorResponse("unable_to_compile", "Compilation failed, more details in the compilation log file."))
-        case CompilationAborted =>
-          talk
-            .setStatus(HStatus.ServiceUnavailable)
-            .writeJson(ErrorResponse("unable_to_compile", s"No compilation task started"))
-        case CompilationUnnecessary =>
-          talk
-            .setStatus(HStatus.NotModified)
-            .writeJson(false)
-      } recover {
-        case e =>
-          logError(s"Unable to compile paper $paperId", e)
-          talk
-            .setStatus(HStatus.InternalServerError)
-            .writeJson(ErrorResponse("unable_to_compile", "Compilation failed, more details in the compilation log file."))
+          promise.future.map {
+            case CompilationSucceeded | CompilationFailed(true) =>
+              talk.writeJson(true)
+            case CompilationFailed(false) =>
+              talk
+                .setStatus(HStatus.InternalServerError)
+                .writeJson(ErrorResponse("unable_to_compile", "Compilation failed, more details in the compilation log file."))
+            case CompilationAborted =>
+              talk
+                .setStatus(HStatus.ServiceUnavailable)
+                .writeJson(ErrorResponse("unable_to_compile", s"No compilation task started"))
+            case CompilationUnnecessary =>
+              talk
+                .setStatus(HStatus.NotModified)
+                .writeJson(false)
+          } recover {
+            case e =>
+              logError(s"Unable to compile paper $paperId", e)
+              talk
+                .setStatus(HStatus.InternalServerError)
+                .writeJson(ErrorResponse("unable_to_compile", "Compilation failed, more details in the compilation log file."))
+          }
+        case None =>
+          Future.successful(talk
+            .setStatus(HStatus.BadRequest)
+            .writeJson(ErrorResponse("unable_to_compile", "You did not provide identity data")))
       }
 
     case _ =>

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/CompilerLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/CompilerLet.scala
@@ -35,7 +35,7 @@ import gnieh.sohva.control.CouchClient
 
 class CompilerLet(paperId: String, val couch: CouchClient, dispatcher: ActorRef, config: Config, logger: Logger) extends AsyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Future[Any] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Future[Any] = permissions match {
     case Compile() =>
       val promise = Promise[CompilationStatus]()
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetCompilerSettingsLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetCompilerSettingsLet.scala
@@ -38,11 +38,10 @@ import gnieh.sohva.control.CouchClient
  *
  *  @author Lucas Satabin
  */
-class GetCompilerSettingsLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncRoleLet(paperId, config, logger) {
+class GetCompilerSettingsLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Any] = role match {
-    case Author =>
-      // only authors users may see other compiler settings
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+    case Configure() =>
       entityManager("blue_papers").getComponent[CompilerSettings](paperId) map {
         // we are sure that the settings has a revision because it comes from the database
         case Some(settings) =>
@@ -59,7 +58,7 @@ class GetCompilerSettingsLet(paperId: String, val couch: CouchClient, config: Co
       Try(
         talk
           .setStatus(HStatus.Forbidden)
-          .writeJson(ErrorResponse("no_sufficient_rights", "Only authors may see compiler settings")))
+          .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to see compiler settings")))
 
   }
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetCompilerSettingsLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetCompilerSettingsLet.scala
@@ -40,7 +40,7 @@ import gnieh.sohva.control.CouchClient
  */
 class GetCompilerSettingsLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
     case Configure() =>
       entityManager("blue_papers").getComponent[CompilerSettings](paperId) map {
         // we are sure that the settings has a revision because it comes from the database

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetCompilerSettingsLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetCompilerSettingsLet.scala
@@ -40,7 +40,7 @@ import gnieh.sohva.control.CouchClient
  */
 class GetCompilerSettingsLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
     case Configure() =>
       entityManager("blue_papers").getComponent[CompilerSettings](paperId) map {
         // we are sure that the settings has a revision because it comes from the database

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetLogLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetLogLet.scala
@@ -45,10 +45,10 @@ object GetLogLet {
 
 }
 
-class GetLogLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncRoleLet(paperId, config, logger) {
+class GetLogLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Any] = role match {
-    case Author =>
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+    case Compile() =>
 
       import FileUtils._
 
@@ -74,7 +74,7 @@ class GetLogLet(paperId: String, val couch: CouchClient, config: Config, logger:
       Try(
         talk
           .setStatus(HStatus.Forbidden)
-          .writeJson(ErrorResponse("no_sufficient_rights", "Only authors may see compilation results")))
+          .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to see compilation results")))
 
   }
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetLogLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetLogLet.scala
@@ -47,7 +47,7 @@ object GetLogLet {
 
 class GetLogLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
     case Compile() =>
 
       import FileUtils._

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetLogLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetLogLet.scala
@@ -47,7 +47,7 @@ object GetLogLet {
 
 class GetLogLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
     case Compile() =>
 
       import FileUtils._

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPagesLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPagesLet.scala
@@ -42,12 +42,12 @@ import gnieh.sohva.control.CouchClient
  *
  *  @author Lucas Satabin
  */
-class GetPagesLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncRoleLet(paperId, config, logger) {
+class GetPagesLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
   import FileUtils._
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Any] = role match {
-    case Author | Reviewer =>
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+    case Read() =>
 
       // the generated pdf file
       val pdfFile = configuration.buildDir(paperId) / s"main.pdf"
@@ -76,7 +76,7 @@ class GetPagesLet(paperId: String, val couch: CouchClient, config: Config, logge
       Try(
         talk
           .setStatus(HStatus.Forbidden)
-          .writeJson(ErrorResponse("no_sufficient_rights", "Only authors and reviewers may see the number of pages")))
+          .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to see the number of pages")))
 
   }
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPagesLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPagesLet.scala
@@ -46,7 +46,7 @@ class GetPagesLet(paperId: String, val couch: CouchClient, config: Config, logge
 
   import FileUtils._
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
     case Read() =>
 
       // the generated pdf file

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPagesLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPagesLet.scala
@@ -46,7 +46,7 @@ class GetPagesLet(paperId: String, val couch: CouchClient, config: Config, logge
 
   import FileUtils._
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
     case Read() =>
 
       // the generated pdf file

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPdfLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPdfLet.scala
@@ -37,7 +37,7 @@ import resource._
 
 class GetPdfLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
     case View() =>
 
       import FileUtils._

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPdfLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPdfLet.scala
@@ -35,10 +35,10 @@ import gnieh.sohva.control.CouchClient
 
 import resource._
 
-class GetPdfLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncRoleLet(paperId, config, logger) {
+class GetPdfLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Any] = role match {
-    case Author | Reviewer =>
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+    case View() =>
 
       import FileUtils._
 
@@ -72,7 +72,7 @@ class GetPdfLet(paperId: String, val couch: CouchClient, config: Config, logger:
       Try(
         talk
           .setStatus(HStatus.Forbidden)
-          .writeJson(ErrorResponse("no_sufficient_rights", "Only authors and reviewers may see compiled paper")))
+          .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to see compiled paper")))
 
   }
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPdfLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPdfLet.scala
@@ -37,7 +37,7 @@ import resource._
 
 class GetPdfLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
     case View() =>
 
       import FileUtils._

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPngLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPngLet.scala
@@ -43,7 +43,7 @@ class GetPngLet(paperId: String, page: Int, val couch: CouchClient, config: Conf
 
   import FileUtils._
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
     case View() =>
       val pngPage = paperId + "-" + page + ".png"
       val pngFile = configuration.buildDir(paperId) / pngPage

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPngLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPngLet.scala
@@ -39,12 +39,12 @@ import gnieh.sohva.control.CouchClient
 
 import resource._
 
-class GetPngLet(paperId: String, page: Int, val couch: CouchClient, config: Config, logger: Logger) extends SyncRoleLet(paperId, config, logger) {
+class GetPngLet(paperId: String, page: Int, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
   import FileUtils._
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Any] = role match {
-    case Author | Reviewer =>
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+    case View() =>
       val pngPage = paperId + "-" + page + ".png"
       val pngFile = configuration.buildDir(paperId) / pngPage
 
@@ -87,7 +87,7 @@ class GetPngLet(paperId: String, page: Int, val couch: CouchClient, config: Conf
       Try(
         talk
           .setStatus(HStatus.Forbidden)
-          .writeJson(ErrorResponse("no_sufficient_rights", "Only authors and reviewers may see compiled paper")))
+          .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to see compiled paper")))
 
   }
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPngLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetPngLet.scala
@@ -43,7 +43,7 @@ class GetPngLet(paperId: String, page: Int, val couch: CouchClient, config: Conf
 
   import FileUtils._
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
     case View() =>
       val pngPage = paperId + "-" + page + ".png"
       val pngFile = configuration.buildDir(paperId) / pngPage

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetSyncTeXLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetSyncTeXLet.scala
@@ -34,12 +34,12 @@ import gnieh.sohva.control.CouchClient
 
 import resource._
 
-class GetSyncTeXLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncRoleLet(paperId, config, logger) {
+class GetSyncTeXLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
   import FileUtils._
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Any] = role match {
-    case Author =>
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+    case Read() =>
       val syncTeXFile = configuration.buildDir(paperId) / s"main.synctex.gz"
 
       if (!syncTeXFile.exists)
@@ -63,7 +63,7 @@ class GetSyncTeXLet(paperId: String, val couch: CouchClient, config: Config, log
       Try(
         talk
           .setStatus(HStatus.Forbidden)
-          .writeJson(ErrorResponse("no_sufficient_rights", "Only authors may retrieve SyncTeX data")))
+          .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to retrieve SyncTeX data")))
 
   }
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetSyncTeXLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetSyncTeXLet.scala
@@ -38,7 +38,7 @@ class GetSyncTeXLet(paperId: String, val couch: CouchClient, config: Config, log
 
   import FileUtils._
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
     case Read() =>
       val syncTeXFile = configuration.buildDir(paperId) / s"main.synctex.gz"
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetSyncTeXLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/GetSyncTeXLet.scala
@@ -38,7 +38,7 @@ class GetSyncTeXLet(paperId: String, val couch: CouchClient, config: Config, log
 
   import FileUtils._
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
     case Read() =>
       val syncTeXFile = configuration.buildDir(paperId) / s"main.synctex.gz"
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/ModifyCompilerLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/ModifyCompilerLet.scala
@@ -44,7 +44,7 @@ import akka.actor.ActorRef
  */
 class ModifyCompilerLet(paperId: String, val couch: CouchClient, dispatcher: ActorRef, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
     case Configure() =>
       (talk.req.octets, talk.req.header("if-match")) match {
         case (Some(octets), knownRev @ Some(_)) =>

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/ModifyCompilerLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/ModifyCompilerLet.scala
@@ -42,10 +42,10 @@ import akka.actor.ActorRef
  *
  *  @author Lucas Satabin
  */
-class ModifyCompilerLet(paperId: String, val couch: CouchClient, dispatcher: ActorRef, config: Config, logger: Logger) extends SyncRoleLet(paperId, config, logger) {
+class ModifyCompilerLet(paperId: String, val couch: CouchClient, dispatcher: ActorRef, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Any] = role match {
-    case Author =>
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+    case Configure() =>
       (talk.req.octets, talk.req.header("if-match")) match {
         case (Some(octets), knownRev @ Some(_)) =>
           val manager = entityManager("blue_papers")
@@ -107,8 +107,7 @@ class ModifyCompilerLet(paperId: String, val couch: CouchClient, dispatcher: Act
       Try(
         talk
           .setStatus(HStatus.Forbidden)
-          .writeJson(ErrorResponse("no_sufficient_rights", "Only authors may change compiler settings")))
+          .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to change compiler settings")))
   }
 
 }
-

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/ModifyCompilerLet.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/let/ModifyCompilerLet.scala
@@ -44,7 +44,7 @@ import akka.actor.ActorRef
  */
 class ModifyCompilerLet(paperId: String, val couch: CouchClient, dispatcher: ActorRef, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Any] = permissions match {
     case Configure() =>
       (talk.req.octets, talk.req.header("if-match")) match {
         case (Some(octets), knownRev @ Some(_)) =>

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/CoreApi.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/CoreApi.scala
@@ -82,6 +82,9 @@ class CoreApi(
     // add or remove people involved in this paper (authors, reviewers)
     case p"papers/$paperid/roles" =>
       new ModifyRolesLet(paperid, couch, config, logger)
+    // add or remove permissions for each role in this paper
+    case p"papers/$paperid/permissions" =>
+      new ModifyPermissionsLet(paperid, couch, config, logger)
   }
 
   private val GetUsersLet = new GetUsersLet(couch, config, logger)
@@ -105,6 +108,9 @@ class CoreApi(
     // gets the list of people involved in this paper with their role
     case p"papers/$paperid/roles" =>
       new GetPaperRolesLet(paperid, couch, config, logger)
+    // gets the list of permissions for each role in this paper
+    case p"papers/$paperid/permissions" =>
+      new GetPaperPermissionsLet(paperid, couch, config, logger)
     // gets the paper data
     case p"papers/$paperid/info" =>
       new GetPaperInfoLet(paperid, couch, config, logger)

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/CoreApi.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/CoreApi.scala
@@ -76,6 +76,9 @@ class CoreApi(
     // save the data for the authenticated user
     case p"users/$username/info" =>
       new ModifyUserLet(username, couch, config, logger)
+    // save the permission set for the authenticated user
+    case p"users/$username/permissions" =>
+      new ModifyUserPermissionsLet(username, couch, config, logger)
     // modify paper information such as paper name
     case p"papers/$paperid/info" =>
       new ModifyPaperLet(paperid, couch, config, logger)
@@ -96,6 +99,9 @@ class CoreApi(
     // gets the data of the given user
     case p"users/$username/info" =>
       new GetUserInfoLet(username, couch, config, logger)
+    // get the permission sets available to the user
+    case p"users/$username/permissions" =>
+      new GetUserPermissionsLet(username, couch, config, logger)
     // gets the list of papers the given user is involved in
     case p"users/$username/papers" =>
       new GetUserPapersLet(username, couch, config, logger)

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/BackupPaperLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/BackupPaperLet.scala
@@ -50,7 +50,7 @@ import gnieh.sohva.control.CouchClient
  */
 class BackupPaperLet(format: String, paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
     case Download() =>
       entityManager("blue_papers").getComponent[Paper](paperId) map {
         case Some(Paper(_, name, _)) =>

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/BackupPaperLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/BackupPaperLet.scala
@@ -48,10 +48,10 @@ import gnieh.sohva.control.CouchClient
  *
  *  @author Lucas Satabin
  */
-class BackupPaperLet(format: String, paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncRoleLet(paperId, config, logger) {
+class BackupPaperLet(format: String, paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Unit] = role match {
-    case Author =>
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+    case Download() =>
       entityManager("blue_papers").getComponent[Paper](paperId) map {
         case Some(Paper(_, name, _)) =>
           // only authors may backup the paper sources
@@ -96,7 +96,7 @@ class BackupPaperLet(format: String, paperId: String, val couch: CouchClient, co
     case _ =>
       Try(talk
         .setStatus(HStatus.Forbidden)
-        .writeJson(ErrorResponse("no_sufficient_rights", "Only authors may backup the paper sources")))
+        .writeJson(ErrorResponse("no_sufficient_rights", "You have no right to download the paper sources")))
   }
 
 }

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/BackupPaperLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/BackupPaperLet.scala
@@ -50,7 +50,7 @@ import gnieh.sohva.control.CouchClient
  */
 class BackupPaperLet(format: String, paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
     case Download() =>
       entityManager("blue_papers").getComponent[Paper](paperId) map {
         case Some(Paper(_, name, _)) =>

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/DeletePaper.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/DeletePaper.scala
@@ -57,10 +57,10 @@ class DeletePaperLet(
   config: Config,
   recaptcha: ReCaptcha,
   logger: Logger)
-    extends SyncRoleLet(paperId, config, logger) {
+    extends SyncPermissionLet(paperId, config, logger) {
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Unit] = role match {
-    case Author =>
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+    case Delete() =>
       // only authors may delete a paper
       // first delete the paper files
       import FileUtils._
@@ -99,7 +99,7 @@ class DeletePaperLet(
       Success(
         talk
           .setStatus(HStatus.Forbidden)
-          .writeJson(ErrorResponse("no_sufficient_rights", "Only authors may delete a paper")))
+          .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to delete this paper")))
 
   }
 

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/DeletePaper.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/DeletePaper.scala
@@ -59,7 +59,7 @@ class DeletePaperLet(
   logger: Logger)
     extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
     case Delete() =>
       // only authors may delete a paper
       // first delete the paper files

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/DeletePaper.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/DeletePaper.scala
@@ -59,7 +59,7 @@ class DeletePaperLet(
   logger: Logger)
     extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
     case Delete() =>
       // only authors may delete a paper
       // first delete the paper files

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/DeleteResourceLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/DeleteResourceLet.scala
@@ -36,10 +36,10 @@ import gnieh.sohva.control.CouchClient
  *
  *  @author Lucas Satabin
  */
-class DeleteResourceLet(paperId: String, resourceName: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncRoleLet(paperId, config, logger) {
+class DeleteResourceLet(paperId: String, resourceName: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Unit] = Try(role match {
-    case Author =>
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
+    case Edit() =>
       // only authors may get a resource
       val file = configuration.resource(paperId, resourceName)
 
@@ -52,7 +52,7 @@ class DeleteResourceLet(paperId: String, resourceName: String, val couch: CouchC
     case _ =>
       talk
         .setStatus(HStatus.Forbidden)
-        .writeJson(ErrorResponse("no_sufficient_rights", "Only authors may delete resources"))
+        .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to delete resources"))
   })
 
 }

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/DeleteResourceLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/DeleteResourceLet.scala
@@ -38,7 +38,7 @@ import gnieh.sohva.control.CouchClient
  */
 class DeleteResourceLet(paperId: String, resourceName: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
     case Edit() =>
       // only authors may get a resource
       val file = configuration.resource(paperId, resourceName)

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/DeleteResourceLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/DeleteResourceLet.scala
@@ -38,7 +38,7 @@ import gnieh.sohva.control.CouchClient
  */
 class DeleteResourceLet(paperId: String, resourceName: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
     case Edit() =>
       // only authors may get a resource
       val file = configuration.resource(paperId, resourceName)

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetPaperInfoLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetPaperInfoLet.scala
@@ -19,7 +19,7 @@ package impl
 package paper
 
 import http.{
-  SyncRoleLet,
+  SyncPermissionLet,
   ErrorResponse
 }
 
@@ -28,11 +28,7 @@ import common.{
   UserInfo
 }
 
-import permission.{
-  Role,
-  Author,
-  Reviewer
-}
+import permission._
 
 import couch.{
   Paper,
@@ -56,11 +52,10 @@ import gnieh.sohva.control.CouchClient
  *
  *  @author Lucas Satabin
  */
-class GetPaperInfoLet(paperid: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncRoleLet(paperid, config, logger) {
+class GetPaperInfoLet(paperid: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperid, config, logger) {
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Unit] = role match {
-    case Author | Reviewer =>
-      // only authenticated users may see other people information
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+    case Configure() =>
       val manager = entityManager("blue_papers")
       for(paper <- manager.getComponent[Paper](paperid))
         yield paper match {
@@ -75,7 +70,7 @@ class GetPaperInfoLet(paperid: String, val couch: CouchClient, config: Config, l
       Try(
         talk
           .setStatus(HStatus.Forbidden)
-          .writeJson(ErrorResponse("no_sufficient_rights", "Only authors or reviewers may see paper information")))
+          .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to see paper information")))
   }
 
 }

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetPaperInfoLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetPaperInfoLet.scala
@@ -54,7 +54,7 @@ import gnieh.sohva.control.CouchClient
  */
 class GetPaperInfoLet(paperid: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperid, config, logger) {
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
     case Configure() =>
       val manager = entityManager("blue_papers")
       for(paper <- manager.getComponent[Paper](paperid))

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetPaperInfoLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetPaperInfoLet.scala
@@ -54,7 +54,7 @@ import gnieh.sohva.control.CouchClient
  */
 class GetPaperInfoLet(paperid: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperid, config, logger) {
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
     case Configure() =>
       val manager = entityManager("blue_papers")
       for(paper <- manager.getComponent[Paper](paperid))

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetPaperPermissionsLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetPaperPermissionsLet.scala
@@ -54,7 +54,7 @@ import gnieh.sohva.control.CouchClient
  */
 class GetPaperPermissionsLet(paperid: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperid, config, logger) {
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
     case Configure() =>
       val manager = entityManager("blue_papers")
       for(Some(phase @ PaperPhase(_, _, permissions, _)) <- manager.getComponent[PaperPhase](paperid))

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetPaperPermissionsLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetPaperPermissionsLet.scala
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the \BlueLaTeX project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gnieh.blue
+package core
+package impl
+package paper
+
+import http.{
+  SyncPermissionLet,
+  ErrorResponse
+}
+
+import common.{
+  Logger,
+  UserInfo
+}
+
+import permission._
+
+import couch.{
+  Paper,
+  PaperPhase
+}
+
+import com.typesafe.config.Config
+
+import tiscaf.{
+  HTalk,
+  HStatus
+}
+
+import scala.io.Source
+
+import scala.util.Try
+
+import gnieh.sohva.control.CouchClient
+
+/** Returns the paper roles
+ *
+ *  @author Lucas Satabin
+ */
+class GetPaperPermissionsLet(paperid: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperid, config, logger) {
+
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+    case Configure() =>
+      val manager = entityManager("blue_papers")
+      for(Some(phase @ PaperPhase(_, _, permissions, _)) <- manager.getComponent[PaperPhase](paperid))
+        yield talk.writeJson(permissions, phase._rev.get)
+
+    case _ =>
+      Try(
+        talk
+          .setStatus(HStatus.Forbidden)
+          .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to see paper permissions")))
+  }
+
+}

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetPaperPermissionsLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetPaperPermissionsLet.scala
@@ -54,7 +54,7 @@ import gnieh.sohva.control.CouchClient
  */
 class GetPaperPermissionsLet(paperid: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperid, config, logger) {
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
     case Configure() =>
       val manager = entityManager("blue_papers")
       for(Some(phase @ PaperPhase(_, _, permissions, _)) <- manager.getComponent[PaperPhase](paperid))

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetPaperRolesLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetPaperRolesLet.scala
@@ -19,7 +19,7 @@ package impl
 package paper
 
 import http.{
-  SyncRoleLet,
+  SyncPermissionLet,
   ErrorResponse
 }
 
@@ -28,11 +28,7 @@ import common.{
   UserInfo
 }
 
-import permission.{
-  Role,
-  Author,
-  Reviewer
-}
+import permission._
 
 import couch.{
   Paper,
@@ -56,11 +52,10 @@ import gnieh.sohva.control.CouchClient
  *
  *  @author Lucas Satabin
  */
-class GetPaperRolesLet(paperid: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncRoleLet(paperid, config, logger) {
+class GetPaperRolesLet(paperid: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperid, config, logger) {
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Unit] = role match {
-    case Author | Reviewer =>
-      // only authenticated users may see other people information
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+    case Configure() =>
       val manager = entityManager("blue_papers")
       for(roles <- manager.getComponent[PaperRole](paperid))
         yield roles match {
@@ -75,7 +70,7 @@ class GetPaperRolesLet(paperid: String, val couch: CouchClient, config: Config, 
       Try(
         talk
           .setStatus(HStatus.Forbidden)
-          .writeJson(ErrorResponse("no_sufficient_rights", "Only authors or reviewers may see paper roles")))
+          .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to see paper roles")))
   }
 
 }

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetPaperRolesLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetPaperRolesLet.scala
@@ -61,7 +61,7 @@ class GetPaperRolesLet(paperid: String, val couch: CouchClient, config: Config, 
         yield roles match {
           // we are sure that the paper has a revision because it comes from the database
           case Some(roles) =>
-            talk.writeJson(Map("authors" -> roles.authors.users, "reviewers" -> roles.reviewers.users), roles._rev.get)
+            talk.writeJson(Map("authors" -> roles.authors.users, "reviewers" -> roles.reviewers.users, "guests" -> roles.guests.users), roles._rev.get)
           case None =>
             talk.setStatus(HStatus.NotFound).writeJson(ErrorResponse("not_found", s"Paper $paperid not found"))
         }

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetPaperRolesLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetPaperRolesLet.scala
@@ -54,7 +54,7 @@ import gnieh.sohva.control.CouchClient
  */
 class GetPaperRolesLet(paperid: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperid, config, logger) {
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
     case Configure() =>
       val manager = entityManager("blue_papers")
       for(roles <- manager.getComponent[PaperRole](paperid))

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetPaperRolesLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetPaperRolesLet.scala
@@ -54,7 +54,7 @@ import gnieh.sohva.control.CouchClient
  */
 class GetPaperRolesLet(paperid: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperid, config, logger) {
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
     case Configure() =>
       val manager = entityManager("blue_papers")
       for(roles <- manager.getComponent[PaperRole](paperid))

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetResourceLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetResourceLet.scala
@@ -40,7 +40,7 @@ import gnieh.sohva.control.CouchClient
  */
 class GetResourceLet(paperId: String, resourceName: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
     case Edit() =>
       // only authors may get a resource
       val file = configuration.resource(paperId, resourceName)

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetResourceLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetResourceLet.scala
@@ -38,10 +38,10 @@ import gnieh.sohva.control.CouchClient
  *
  *  @author Lucas Satabin
  */
-class GetResourceLet(paperId: String, resourceName: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncRoleLet(paperId, config, logger) {
+class GetResourceLet(paperId: String, resourceName: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Unit] = Try(role match {
-    case Author =>
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
+    case Edit() =>
       // only authors may get a resource
       val file = configuration.resource(paperId, resourceName)
 
@@ -69,7 +69,7 @@ class GetResourceLet(paperId: String, resourceName: String, val couch: CouchClie
     case _ =>
       talk
         .setStatus(HStatus.Forbidden)
-        .writeJson(ErrorResponse("no_sufficient_rights", "Only authors may get resources"))
+        .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to see resources"))
   })
 
 }

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetResourceLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/GetResourceLet.scala
@@ -40,7 +40,7 @@ import gnieh.sohva.control.CouchClient
  */
 class GetResourceLet(paperId: String, resourceName: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
     case Edit() =>
       // only authors may get a resource
       val file = configuration.resource(paperId, resourceName)

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/JoinPaperLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/JoinPaperLet.scala
@@ -43,17 +43,17 @@ class JoinPaperLet(
   val couch: CouchClient,
   config: Config,
   logger: Logger)
-    extends SyncRoleLet(paperId, config, logger) {
+    extends SyncPermissionLet(paperId, config, logger) {
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Unit] = Try {
-    role match {
-      case Author | Reviewer =>
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try {
+    permissions match {
+      case Edit() | Read() =>
         system.eventStream.publish(Join(peerId, paperId))
         talk.writeJson(true)
       case _ =>
         talk
           .setStatus(HStatus.Unauthorized)
-          .writeJson(ErrorResponse("no_sufficient_rights", "Only authors and reviewers may join a paper"))
+          .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to join the paper"))
     }
   }
 

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/JoinPaperLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/JoinPaperLet.scala
@@ -45,7 +45,7 @@ class JoinPaperLet(
   logger: Logger)
     extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try {
     permissions match {
       case Edit() | Read() =>
         system.eventStream.publish(Join(peerId, paperId))

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/JoinPaperLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/JoinPaperLet.scala
@@ -45,7 +45,7 @@ class JoinPaperLet(
   logger: Logger)
     extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Unit] = Try {
     permissions match {
       case Edit() | Read() =>
         system.eventStream.publish(Join(peerId, paperId))

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/ModifyPaperLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/ModifyPaperLet.scala
@@ -42,10 +42,10 @@ import gnieh.sohva.control.CouchClient
  *
  *  @author Lucas Satabin
  */
-class ModifyPaperLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncRoleLet(paperId, config, logger) {
+class ModifyPaperLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Unit] = role match {
-    case Author =>
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+    case Configure() =>
       // only authors may modify this list
       (talk.req.octets, talk.req.header("if-match")) match {
         case (Some(octets), knownRev @ Some(_)) =>
@@ -105,7 +105,7 @@ class ModifyPaperLet(paperId: String, val couch: CouchClient, config: Config, lo
       Success(
         talk
           .setStatus(HStatus.Forbidden)
-          .writeJson(ErrorResponse("no_sufficient_rights", "Only authors may modify the paper data")))
+          .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to modify the paper data")))
   }
 
 }

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/ModifyPaperLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/ModifyPaperLet.scala
@@ -44,7 +44,7 @@ import gnieh.sohva.control.CouchClient
  */
 class ModifyPaperLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
     case Configure() =>
       // only authors may modify this list
       (talk.req.octets, talk.req.header("if-match")) match {

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/ModifyPaperLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/ModifyPaperLet.scala
@@ -44,7 +44,7 @@ import gnieh.sohva.control.CouchClient
  */
 class ModifyPaperLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
     case Configure() =>
       // only authors may modify this list
       (talk.req.octets, talk.req.header("if-match")) match {

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/ModifyPermissionsLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/ModifyPermissionsLet.scala
@@ -1,0 +1,113 @@
+/*
+ * This file is part of the \BlueLaTeX project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gnieh.blue
+package core
+package impl
+package paper
+
+import http._
+import couch.PaperPhase
+import common._
+import permission._
+
+import com.typesafe.config.Config
+
+import tiscaf._
+
+import gnieh.diffson._
+
+import scala.io.Source
+
+import scala.util.{
+  Try,
+  Success
+}
+
+import gnieh.sohva.control.CouchClient
+
+/** Handle JSON Patches that add/remove/modify permissions for the given paper
+ *
+ *  @author Lucas Satabin
+ */
+class ModifyPermissionsLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
+
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+    case Configure() =>
+      // only authors may modify this list
+      (talk.req.octets, talk.req.header("if-match")) match {
+        case (Some(octets), knownRev @ Some(_)) =>
+          val manager = entityManager("blue_papers")
+          // the modification must be sent as a JSON Patch document
+          // retrieve the paper object from the database
+          manager.getComponent[PaperPhase](paperId) flatMap {
+            case Some(phase @ PaperPhase(_, _, permissions, _)) if phase._rev == knownRev =>
+              talk.readJson[JsonPatch] match {
+                case Some(patch) =>
+                  // the revision matches, we can apply the patch
+                  val permissions1 = patch(permissions)
+                  val permissions2 =
+                    phase.copy(permissions = permissions1).withRev(knownRev)
+                  // and save the new paper data
+                  for(r <- manager.saveComponent(paperId, permissions2))
+                    // save successfully, return ok with the new ETag
+                    // we are sure that the revision is not empty because it comes from the database
+                    yield talk.writeJson(true, r._rev.get)
+                case None =>
+                  // nothing to do
+                  Success(
+                    talk
+                      .setStatus(HStatus.NotModified)
+                      .writeJson(ErrorResponse("nothing_to_do", "No changes sent")))
+              }
+            case Some(_) =>
+              // nothing to do
+              Success(
+                talk
+                  .setStatus(HStatus.Conflict)
+                  .writeJson(ErrorResponse("conflict", "Old role revision provided")))
+
+            case None =>
+              // unknown paper
+              Success(
+                talk
+                  .setStatus(HStatus.NotFound)
+                  .writeJson(ErrorResponse("nothing_to_do", s"Unknown paper $paperId")))
+
+          }
+
+        case (None, _) =>
+          // nothing to do
+          Success(
+            talk
+              .setStatus(HStatus.NotModified)
+              .writeJson(ErrorResponse("nothing_to_do", "No changes sent")))
+
+        case (_, None) =>
+          // known revision was not sent, precondition failed
+          Success(
+            talk
+              .setStatus(HStatus.Conflict)
+              .writeJson(ErrorResponse("conflict", "Paper revision not provided")))
+      }
+    case _ =>
+      Success(
+        talk
+          .setStatus(HStatus.Forbidden)
+          .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to modify the permissions")))
+  }
+
+}
+

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/ModifyPermissionsLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/ModifyPermissionsLet.scala
@@ -44,7 +44,7 @@ import gnieh.sohva.control.CouchClient
  */
 class ModifyPermissionsLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
     case Configure() =>
       // only authors may modify this list
       (talk.req.octets, talk.req.header("if-match")) match {

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/ModifyPermissionsLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/ModifyPermissionsLet.scala
@@ -44,7 +44,7 @@ import gnieh.sohva.control.CouchClient
  */
 class ModifyPermissionsLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
     case Configure() =>
       // only authors may modify this list
       (talk.req.octets, talk.req.header("if-match")) match {

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/ModifyRolesLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/ModifyRolesLet.scala
@@ -57,11 +57,12 @@ class ModifyRolesLet(paperId: String, val couch: CouchClient, config: Config, lo
               talk.readJson[JsonPatch] match {
                 case Some(patch) =>
                   // the revision matches, we can apply the patch
-                  val roles1 = patch(Map("authors" -> roles.authors.users, "reviewers" -> roles.reviewers.users))
+                  val roles1 = patch(Map("authors" -> roles.authors.users, "reviewers" -> roles.reviewers.users, "guests" -> roles.guests.users))
                   val roles2 =
                     roles.copy(
                       authors = roles.authors.copy(users = roles1("authors")),
-                      reviewers = roles.reviewers.copy(users = roles1("reviewers"))).withRev(knownRev)
+                      reviewers = roles.reviewers.copy(users = roles1("reviewers")),
+                      guests = roles.guests.copy(users = roles1("guests"))).withRev(knownRev)
                   // and save the new paper data
                   for(r <- manager.saveComponent(paperId, roles2))
                     // save successfully, return ok with the new ETag

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/ModifyRolesLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/ModifyRolesLet.scala
@@ -42,10 +42,10 @@ import gnieh.sohva.control.CouchClient
  *
  *  @author Lucas Satabin
  */
-class ModifyRolesLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncRoleLet(paperId, config, logger) {
+class ModifyRolesLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Unit] = role match {
-    case Author =>
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+    case Configure() =>
       // only authors may modify this list
       (talk.req.octets, talk.req.header("if-match")) match {
         case (Some(octets), knownRev @ Some(_)) =>
@@ -108,7 +108,7 @@ class ModifyRolesLet(paperId: String, val couch: CouchClient, config: Config, lo
       Success(
         talk
           .setStatus(HStatus.Forbidden)
-          .writeJson(ErrorResponse("no_sufficient_rights", "Only authors may modify the list of involved people")))
+          .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to modify the list of involved people")))
   }
 
 }

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/ModifyRolesLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/ModifyRolesLet.scala
@@ -44,7 +44,7 @@ import gnieh.sohva.control.CouchClient
  */
 class ModifyRolesLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
     case Configure() =>
       // only authors may modify this list
       (talk.req.octets, talk.req.header("if-match")) match {

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/ModifyRolesLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/ModifyRolesLet.scala
@@ -44,7 +44,7 @@ import gnieh.sohva.control.CouchClient
  */
 class ModifyRolesLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Unit] = permissions match {
     case Configure() =>
       // only authors may modify this list
       (talk.req.octets, talk.req.header("if-match")) match {

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/NonSynchronizedResourcesLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/NonSynchronizedResourcesLet.scala
@@ -38,7 +38,7 @@ import gnieh.sohva.control.CouchClient
  */
 class NonSynchronizedResourcesLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
     case Edit() =>
       import FileUtils._
       val files =

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/NonSynchronizedResourcesLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/NonSynchronizedResourcesLet.scala
@@ -36,11 +36,10 @@ import gnieh.sohva.control.CouchClient
  *
  *  @author Lucas Satabin
  */
-class NonSynchronizedResourcesLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncRoleLet(paperId, config, logger) {
+class NonSynchronizedResourcesLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Unit] = Try(role match {
-    case Author =>
-      // only authors may get the list of synchronized resources
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
+    case Edit() =>
       import FileUtils._
       val files =
         configuration
@@ -56,7 +55,7 @@ class NonSynchronizedResourcesLet(paperId: String, val couch: CouchClient, confi
     case _ =>
       talk
         .setStatus(HStatus.Forbidden)
-        .writeJson(ErrorResponse("no_sufficient_rights", "Only authors may see the list of non synchronized resources"))
+        .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to see the list of non synchronized resources"))
   })
 
 }

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/NonSynchronizedResourcesLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/NonSynchronizedResourcesLet.scala
@@ -38,7 +38,7 @@ import gnieh.sohva.control.CouchClient
  */
 class NonSynchronizedResourcesLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
     case Edit() =>
       import FileUtils._
       val files =

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/PartPaperLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/PartPaperLet.scala
@@ -42,11 +42,11 @@ class PartPaperLet(
   system: ActorSystem,
   val couch: CouchClient,
   config: Config,
-  logger: Logger) extends SyncRoleLet(paperId, config, logger) {
+  logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Unit] = Try {
-    role match {
-      case Author | Reviewer =>
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try {
+    permissions match {
+      case Edit() | Read() =>
         // remove this peer from the current session
         for(peers <- SessionKeys.get[Set[String]](SessionKeys.Peers))
           talk.ses(SessionKeys.Peers) = peers - peerId
@@ -56,7 +56,7 @@ class PartPaperLet(
       case _ =>
         talk
           .setStatus(HStatus.Unauthorized)
-          .writeJson(ErrorResponse("no_sufficient_rights", "Only authors and reviewers may leave a paper"))
+          .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to leave the paper"))
     }
   }
 

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/PartPaperLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/PartPaperLet.scala
@@ -44,7 +44,7 @@ class PartPaperLet(
   config: Config,
   logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try {
     permissions match {
       case Edit() | Read() =>
         // remove this peer from the current session

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/PartPaperLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/PartPaperLet.scala
@@ -44,7 +44,7 @@ class PartPaperLet(
   config: Config,
   logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Unit] = Try {
     permissions match {
       case Edit() | Read() =>
         // remove this peer from the current session

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/SaveResourceLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/SaveResourceLet.scala
@@ -68,7 +68,7 @@ class SaveResourceLet(paperId: String, resourceName: String, val couch: CouchCli
 
   private var image: Option[Array[Byte]] = None
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
     case Edit() =>
       // only authors may upload a resource
       val data = image.orElse(talk.req.octets)

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/SaveResourceLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/SaveResourceLet.scala
@@ -41,7 +41,7 @@ import gnieh.sohva.control.CouchClient
  *
  *  @author Lucas Satabin
  */
-class SaveResourceLet(paperId: String, resourceName: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncRoleLet(paperId, config, logger) {
+class SaveResourceLet(paperId: String, resourceName: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
   override def partsAcceptor(reqInfo: HReqHeaderData) =
     Some(new ResourcePartsAcceptor(reqInfo))
@@ -68,8 +68,8 @@ class SaveResourceLet(paperId: String, resourceName: String, val couch: CouchCli
 
   private var image: Option[Array[Byte]] = None
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Unit] = Try(role match {
-    case Author =>
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
+    case Edit() =>
       // only authors may upload a resource
       val data = image.orElse(talk.req.octets)
 
@@ -100,7 +100,7 @@ class SaveResourceLet(paperId: String, resourceName: String, val couch: CouchCli
     case _ =>
       talk
         .setStatus(HStatus.Forbidden)
-        .writeJson(ErrorResponse("no_sufficient_rights", "Only authors may upload resources"))
+        .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to upload resources"))
   })
 
 }

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/SaveResourceLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/SaveResourceLet.scala
@@ -68,7 +68,7 @@ class SaveResourceLet(paperId: String, resourceName: String, val couch: CouchCli
 
   private var image: Option[Array[Byte]] = None
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
     case Edit() =>
       // only authors may upload a resource
       val data = image.orElse(talk.req.octets)

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/SynchronizedResourcesLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/SynchronizedResourcesLet.scala
@@ -36,18 +36,17 @@ import gnieh.sohva.control.CouchClient
  *
  *  @author Lucas Satabin
  */
-class SynchronizedResourcesLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncRoleLet(paperId, config, logger) {
+class SynchronizedResourcesLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Unit] = Try(role match {
-    case Author =>
-      // only authors may get the list of synchronized resources
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
+    case Edit() =>
       import FileUtils._
       val files = configuration.paperDir(paperId).filter(_.extension.matches(synchronizedExt)).map(_.getName)
       talk.writeJson(files)
     case _ =>
       talk
         .setStatus(HStatus.Forbidden)
-        .writeJson(ErrorResponse("no_sufficient_rights", "Only authors may see the list of synchronized resources"))
+        .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to see the list of synchronized resources"))
   })
 
 }

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/SynchronizedResourcesLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/SynchronizedResourcesLet.scala
@@ -38,7 +38,7 @@ import gnieh.sohva.control.CouchClient
  */
 class SynchronizedResourcesLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
     case Edit() =>
       import FileUtils._
       val files = configuration.paperDir(paperId).filter(_.extension.matches(synchronizedExt)).map(_.getName)

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/paper/SynchronizedResourcesLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/paper/SynchronizedResourcesLet.scala
@@ -38,7 +38,7 @@ import gnieh.sohva.control.CouchClient
  */
 class SynchronizedResourcesLet(paperId: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
     case Edit() =>
       import FileUtils._
       val files = configuration.paperDir(paperId).filter(_.extension.matches(synchronizedExt)).map(_.getName)

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/user/GetUserPermissionsLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/user/GetUserPermissionsLet.scala
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the \BlueLaTeX project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gnieh.blue
+package core
+package impl
+package user
+
+import http._
+import couch.UserPermissions
+
+import common._
+
+import com.typesafe.config.Config
+
+import tiscaf._
+
+import gnieh.sohva.control.CouchClient
+
+import scala.io.Source
+
+import scala.util.Try
+
+/** Returns the list of permissions a user defined.
+ *
+ *  @author Lucas Satabin
+ */
+class GetUserPermissionsLet(username: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncBlueLet(config, logger) with SyncAuthenticatedLet {
+
+  def authenticatedAct(user: UserInfo)(implicit talk: HTalk): Try[Any] = {
+    val namesOnly = talk.req.param("names_only").map(_ == "true").getOrElse(false)
+    // built-in permissions
+    val builtin = config.getBuiltInPermissions
+    val manager = entityManager("blue_users")
+    for(perms <- manager.getComponent[UserPermissions](f"org.couchdb.user:${user.name}"))
+      yield perms match {
+        case Some(p @ UserPermissions(_, perms)) =>
+          if(namesOnly)
+            talk.writeJson(builtin.keys ++ perms.keys, p._rev.get)
+          else
+            talk.writeJson(builtin ++ perms, p._rev.get)
+        case None =>
+          if(namesOnly)
+            talk.writeJson(builtin.keys)
+          else
+            talk.writeJson(builtin)
+      }
+  }
+}

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/user/ModifyUserPermissionsLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/user/ModifyUserPermissionsLet.scala
@@ -1,0 +1,123 @@
+/*
+ * This file is part of the \BlueLaTeX project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gnieh.blue
+package core
+package impl
+package user
+
+import http._
+import couch.UserPermissions
+import common._
+
+import com.typesafe.config.Config
+
+import tiscaf._
+
+import gnieh.diffson._
+
+import scala.io.Source
+
+import scala.util.{
+  Try,
+  Success,
+  Failure
+}
+
+import gnieh.sohva.control.CouchClient
+
+/** Handle JSON Patches that modify the user defined permissions
+ *
+ *  @author Lucas Satabin
+ */
+class ModifyUserPermissionsLet(username: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncBlueLet(config, logger) with SyncAuthenticatedLet {
+
+  def authenticatedAct(user: UserInfo)(implicit talk: HTalk): Try[Unit] =
+    if(username == user.name) {
+      // a user can only modify his own data
+      (talk.req.octets, talk.req.header("if-match")) match {
+        case (Some(octets), knownRev @ Some(_)) =>
+          val db = database(blue_users)
+          // the modification must be sent as a JSON Patch document
+          // retrieve the user object from the database
+          val manager = entityManager("blue_users")
+          val userid = s"org.couchdb.user:$username"
+          manager.getComponent[UserPermissions](userid) flatMap {
+            case Some(perms) if perms._rev == knownRev =>
+              patchAndSave(userid, perms, knownRev)
+
+            case Some(_) =>
+              // old revision sent
+              Success(
+                talk
+                  .setStatus(HStatus.Conflict)
+                  .writeJson(ErrorResponse("conflict", "Old revision provided")))
+
+            case None =>
+              patchAndSave(userid, defaultPermissions(userid), None)
+          }
+
+        case (None, _) =>
+          // nothing to do
+          Success(
+            talk
+              .setStatus(HStatus.NotModified)
+              .writeJson(ErrorResponse("nothing_to_do", "No changes sent")))
+
+        case (_, None) =>
+          // known revision was not sent, precondition failed
+          Success(
+            talk
+              .setStatus(HStatus.Conflict)
+              .writeJson(ErrorResponse("conflict", "User revision not provided")))
+      }
+    } else {
+      Success(
+        talk
+          .setStatus(HStatus.Forbidden)
+          .writeJson(ErrorResponse("no_sufficient_rights", "A user can only modify his own data")))
+    }
+
+    private def defaultPermissions(userid: String) =
+      UserPermissions(f"$userid:permissions", config.getBuiltInPermissions)
+
+    private def patchAndSave(userid: String, perms: UserPermissions, knownRev: Option[String])(implicit talk: HTalk) =
+      talk.readJson[JsonPatch] match {
+        case Some(patch) =>
+          // the revision matches, we can apply the patch
+          val perms1 = perms.copy(permissions = patch(perms.permissions)).withRev(knownRev)
+          // and save the new paper data
+          (for(u <- entityManager("blue_users").saveComponent(userid, perms1))
+            yield {
+                // save successfully, return ok with the new ETag
+                // we are sure that the revision is not empty because it comes from the database
+                talk.writeJson(true, u._rev.get)
+            }) recover {
+              case e =>
+                logError(s"Unable to save new permissions for user $userid", e)
+                talk
+                  .setStatus(HStatus.NotModified)
+                  .writeJson(ErrorResponse("cannot_save_data", "The changes could not be saved, please retry"))
+            }
+        case None =>
+          // nothing to do
+          Success(
+            talk
+              .setStatus(HStatus.NotModified)
+              .writeJson(ErrorResponse("nothing_to_do", "No changes sent")))
+      }
+
+}
+

--- a/blue-core/src/main/scala/gnieh/blue/core/impl/user/SaveUserPermissionsLet.scala
+++ b/blue-core/src/main/scala/gnieh/blue/core/impl/user/SaveUserPermissionsLet.scala
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the \BlueLaTeX project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gnieh.blue
+package core
+package impl
+package user
+
+import http._
+import couch.UserPermissions
+
+import common._
+
+import com.typesafe.config.Config
+
+import tiscaf._
+
+import gnieh.sohva.control.CouchClient
+
+import scala.io.Source
+
+import scala.util.Try
+
+/** Save the user permissions with the given name.
+ *
+ *  @author Lucas Satabin
+ */
+class SaveUserPermissionsLet(username: String, val couch: CouchClient, config: Config, logger: Logger) extends SyncBlueLet(config, logger) with SyncAuthenticatedLet {
+
+  def authenticatedAct(user: UserInfo)(implicit talk: HTalk): Try[Any] = {
+    val namesOnly = talk.req.param("names_only").map(_ == "true").getOrElse(false)
+    val manager = entityManager("blue_users")
+    for(perms <- manager.getComponent[UserPermissions](f"org.couchdb.user:${user.name}"))
+      yield perms match {
+        case Some(p @ UserPermissions(_, perms)) =>
+          if(namesOnly)
+            talk.writeJson(perms.keys, p._rev.get)
+          else
+            talk.writeJson(perms, p._rev.get)
+        case None =>
+          talk.writeJson(Nil)
+      }
+  }
+}

--- a/blue-sync/src/main/scala/gnieh/blue/sync/impl/SyncActor.scala
+++ b/blue-sync/src/main/scala/gnieh/blue/sync/impl/SyncActor.scala
@@ -102,7 +102,7 @@ class SyncActor(
 
     case Part(peerId, _) => {
       logInfo(s"peer $peerId left paper $paperId")
-      val newViews = syncContext.views.filter { case (peer, _) => peer != peerId }
+      val newViews = syncContext.views.filter { case ((peer, _), _) => peer != peerId }
       val newMessages = syncContext.messages - peerId
       context.become(receiving(syncContext.updateViews(newViews).updateMessages(newMessages)))
     }

--- a/blue-sync/src/main/scala/gnieh/blue/sync/impl/let/QLet.scala
+++ b/blue-sync/src/main/scala/gnieh/blue/sync/impl/let/QLet.scala
@@ -47,7 +47,7 @@ import gnieh.sohva.control.CouchClient
  *
  *  @author Lucas Satabin
  */
-class QLet(paperId: String, synchroServer: SynchroServer, val couch: CouchClient, config: Config, logger: Logger) extends SyncRoleLet(paperId, config, logger) {
+class QLet(paperId: String, synchroServer: SynchroServer, val couch: CouchClient, config: Config, logger: Logger) extends SyncPermissionLet(paperId, config, logger) {
 
   override implicit val formats =
     BlueLet.formats +
@@ -56,8 +56,8 @@ class QLet(paperId: String, synchroServer: SynchroServer, val couch: CouchClient
     new SyncActionSerializer +
     new EditSerializer
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Any] = Try(role match {
-    case Author =>
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = Try(permissions match {
+    case Edit() =>
       // only authors may modify the paper content
       talk.req.octets match {
         case Some(octets) => {
@@ -99,7 +99,7 @@ class QLet(paperId: String, synchroServer: SynchroServer, val couch: CouchClient
     case _ =>
       talk
         .setStatus(HStatus.Forbidden)
-        .writeJson(ErrorResponse("no_sufficient_rights", "Only authors may modify the paper content"))
+        .writeJson(ErrorResponse("no_sufficient_rights", "You have no permission to modify the paper content"))
   })
 
 }

--- a/blue-sync/src/main/scala/gnieh/blue/sync/impl/let/QLet.scala
+++ b/blue-sync/src/main/scala/gnieh/blue/sync/impl/let/QLet.scala
@@ -56,7 +56,7 @@ class QLet(paperId: String, synchroServer: SynchroServer, val couch: CouchClient
     new SyncActionSerializer +
     new EditSerializer
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = Try(permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = Try(permissions match {
     case Edit() =>
       // only authors may modify the paper content
       talk.req.octets match {

--- a/blue-sync/src/main/scala/gnieh/blue/sync/impl/let/QLet.scala
+++ b/blue-sync/src/main/scala/gnieh/blue/sync/impl/let/QLet.scala
@@ -56,7 +56,7 @@ class QLet(paperId: String, synchroServer: SynchroServer, val couch: CouchClient
     new SyncActionSerializer +
     new EditSerializer
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Any] = Try(permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Any] = Try(permissions match {
     case Edit() =>
       // only authors may modify the paper content
       talk.req.octets match {

--- a/blue-sync/src/main/scala/gnieh/blue/sync/impl/let/SynchronizePaperLet.scala
+++ b/blue-sync/src/main/scala/gnieh/blue/sync/impl/let/SynchronizePaperLet.scala
@@ -37,10 +37,10 @@ import gnieh.sohva.control.CouchClient
  *  @author Lucas Satabin
  */
 class SynchronizePaperLet(paperId: String, synchroServer: SynchroServer, val couch: CouchClient, config: Config, logger: Logger)
-    extends SyncRoleLet(paperId, config, logger) {
+    extends SyncPermissionLet(paperId, config, logger) {
 
-  def roleAct(user: UserInfo, role: Role)(implicit talk: HTalk): Try[Unit] = Try(role match {
-    case Author =>
+  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
+    case Edit() =>
       // only authors may modify the paper content
       talk.req.octets match {
         case Some(octets) =>
@@ -71,7 +71,7 @@ class SynchronizePaperLet(paperId: String, synchroServer: SynchroServer, val cou
     case _ =>
       talk
         .setStatus(HStatus.Forbidden)
-        .writeJson(ErrorResponse("no_sufficient_rights", "Only authors may modify the paper content"))
+        .writeJson(ErrorResponse("no_sufficient_rights", "You have not permission to modify the paper content"))
   })
 
 }

--- a/blue-sync/src/main/scala/gnieh/blue/sync/impl/let/SynchronizePaperLet.scala
+++ b/blue-sync/src/main/scala/gnieh/blue/sync/impl/let/SynchronizePaperLet.scala
@@ -39,7 +39,7 @@ import gnieh.sohva.control.CouchClient
 class SynchronizePaperLet(paperId: String, synchroServer: SynchroServer, val couch: CouchClient, config: Config, logger: Logger)
     extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: UserInfo, role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
     case Edit() =>
       // only authors may modify the paper content
       talk.req.octets match {

--- a/blue-sync/src/main/scala/gnieh/blue/sync/impl/let/SynchronizePaperLet.scala
+++ b/blue-sync/src/main/scala/gnieh/blue/sync/impl/let/SynchronizePaperLet.scala
@@ -39,7 +39,7 @@ import gnieh.sohva.control.CouchClient
 class SynchronizePaperLet(paperId: String, synchroServer: SynchroServer, val couch: CouchClient, config: Config, logger: Logger)
     extends SyncPermissionLet(paperId, config, logger) {
 
-  def permissionAct(user: Option[UserInfo], role: Role, permissions: List[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
+  def permissionAct(user: Option[UserInfo], role: Role, permissions: Set[Permission])(implicit talk: HTalk): Try[Unit] = Try(permissions match {
     case Edit() =>
       // only authors may modify the paper content
       talk.req.octets match {

--- a/blue-test/src/it/scala/gnieh/blue/scenario/compiler/Compilation.scala
+++ b/blue-test/src/it/scala/gnieh/blue/scenario/compiler/Compilation.scala
@@ -52,6 +52,26 @@ class CompilationSpec extends BlueScenario with SomeUsers with SomePapers {
 
     }
 
+    scenario("A reviewer should be able to register to compilation stream") {
+
+      Given("an authenticated person")
+      val (loggedin, _) = login(gerard)
+
+      loggedin should be(true)
+
+      When("he tries to register to a compilation stream")
+      val exn = evaluating {
+        post[Boolean](List("papers", paper2._id, "compiler"), Map(), headers = Map("Content-Length" -> "0", "Content-Type" -> "application/json"))
+      } should produce[BlueErrorException]
+
+      Then("the server authorizes the registration")
+      exn.status should be(503)
+      val error = exn.error
+      error.name should be("unable_to_compile")
+      error.description should be("No compilation task started")
+
+    }
+
     scenario("An unauthenticated user cannot register to a compilation stream") {
 
       Given("an unauthenticated person")
@@ -61,30 +81,10 @@ class CompilationSpec extends BlueScenario with SomeUsers with SomePapers {
       } should produce[BlueErrorException]
 
       Then("he receives an error message")
-      exn.status should be(401)
-      val error = exn.error
-      error.name should be("unauthorized")
-      error.description should be("This action is only permitted to authenticated people")
-
-    }
-
-    scenario("A reviewer cannot register to a compilation stream") {
-
-      Given("an authenticated person")
-      val (loggedin, _) = login(gerard)
-
-      loggedin should be(true)
-
-      When("he tries to register to a compilation stream of a paper for which he is reviewer")
-      val exn = evaluating {
-        post[Boolean](List("papers", paper2._id, "compiler"), Map(), headers = Map("Content-Length" -> "0", "Content-Type" -> "application/json"))
-      } should produce[BlueErrorException]
-
-      Then("he receives an error message")
       exn.status should be(403)
       val error = exn.error
       error.name should be("no_sufficient_rights")
-      error.description should be("Only authors may compile a paper")
+      error.description should be("You have no permission to compile the paper")
 
     }
 
@@ -104,7 +104,7 @@ class CompilationSpec extends BlueScenario with SomeUsers with SomePapers {
       exn.status should be(403)
       val error = exn.error
       error.name should be("no_sufficient_rights")
-      error.description should be("Only authors may compile a paper")
+      error.description should be("You have no permission to compile the paper")
 
     }
 

--- a/blue-test/src/it/scala/gnieh/blue/scenario/paper/Creation.scala
+++ b/blue-test/src/it/scala/gnieh/blue/scenario/paper/Creation.scala
@@ -27,7 +27,7 @@ import org.scalatest._
  */
 class PaperCreationSpec extends BlueScenario with SomeUsers {
 
-  val predefinedPeople = List(rene)
+  val predefinedPeople = List(rene, gerard)
 
   feature("Any authenticated user must be able to create a new paper with the \\BlueLaTeX service") {
 
@@ -51,6 +51,53 @@ class PaperCreationSpec extends BlueScenario with SomeUsers {
 
       roles.authors should be(Set(rene.username))
       roles.reviewers should be('empty)
+
+      When("the user logs out")
+      val (loggedout, _) = delete[Boolean](List("session"))
+
+      loggedout should be(true)
+
+      Then("he can no longer access the created public paper")
+      val exn = evaluating {
+        get[Int](List("papers", id, "compiled", "pages"))
+      } should produce[BlueErrorException]
+
+      exn.status should be(403)
+
+    }
+
+    scenario("a public paper creation") {
+
+      Given("a an authenticated user person")
+      val (loggedin, _) = post[Boolean](List("session"), Map("username" -> gerard.username, "password" -> gerard.password))
+
+      loggedin should be(true)
+
+      When("he creates a new paper")
+      val title = "On Writing Tests"
+      val (id, _) = post[String](List("papers"), Map("paper_name" -> title, "paper_title" -> title, "visibility" -> "public"))
+
+      Then("the paper can be retrieved from the service")
+      val (paper, _) = get[PaperInfo](List("papers", id, "info"))
+
+      paper.name should be(title)
+
+      val (roles, _) = get[PaperRole](List("papers", id, "roles"))
+
+      roles.authors should be(Set(gerard.username))
+      roles.reviewers should be('empty)
+
+      When("the user logs out")
+      val (loggedout, _) = delete[Boolean](List("session"))
+
+      loggedout should be(true)
+
+      Then("He can still access the created public paper")
+      val exn = evaluating {
+        get[Int](List("papers", id, "compiled", "pages"))
+      } should produce[BlueErrorException]
+
+      exn.status should be(404)
 
     }
 

--- a/blue-test/src/it/scala/gnieh/blue/scenario/user/CustomPermissions.scala
+++ b/blue-test/src/it/scala/gnieh/blue/scenario/user/CustomPermissions.scala
@@ -1,0 +1,314 @@
+/*
+ * This file is part of the \BlueLaTeX project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gnieh.blue
+package scenario
+package user
+
+import org.scalatest._
+import OptionValues._
+
+import gnieh.sohva.UserInfo
+
+import http.ErrorResponse
+
+import gnieh.diffson.JsonDiff
+
+/** Scenarios to test custom permissions management:
+ *   - default permissions
+ *   - overriding built-in permissions
+ *   - adding custom permissions
+ *   - deleting custom permissions
+ *   - deleting overriding permissions
+ *
+ *  @author Lucas Satabin
+ */
+class UserPermissionsSpec extends BlueScenario with SomeUsers {
+
+  val predefinedPeople =
+    List(gerard, rene)
+
+  feature("Any logged in user must be able to manage a list of available permissions"){
+
+    info("Once people are logged into \\BlueLaTeX, available permissions are dependent on identified users")
+
+    scenario("default permissions") {
+
+      Given("a new user")
+      val person = predefinedPeople.head
+
+      When("he is logged in")
+      val (loggedin, _) = post[Boolean](List("session"), Map("username" -> person.username, "password" -> person.password))
+
+      loggedin should be(true)
+
+      Then("he can access default permission sets (private and public)")
+      val (perms, _) = get[Map[String,Map[String,Set[String]]]](List("users", person.username, "permissions"))
+
+      perms.size should be(2)
+      perms.keys should contain("private")
+      perms.keys should contain("public")
+
+      val (loggedout, _) = delete[Boolean](List("session"))
+
+      loggedout should be(true)
+
+    }
+
+    scenario("overriding default permission sets") {
+
+      Given("a new person")
+      val person = predefinedPeople.head
+
+      When("he is logged in")
+      val (loggedin, _) = post[Boolean](List("session"), Map("username" -> person.username, "password" -> person.password))
+
+      loggedin should be(true)
+
+      When("he overwrites the default public permissions")
+      val (perms, headers) = get[Map[String,Map[String,Set[String]]]](List("users", person.username, "permissions"))
+
+      headers.get("ETag") should not be('defined)
+
+      val perms1 = perms.updated("public", perms("public").updated("anonymous", Set()))
+      val p = JsonDiff.diff(perms, perms1)
+
+      val (saved, _) = patch[Boolean](List("users", person.username, "permissions"), p, "")
+
+      saved should be(true)
+
+      Then("he can retrieve the new permission sets")
+      val (perms2, _) = get[Map[String,Map[String,Set[String]]]](List("users", person.username, "permissions"))
+
+      perms2 should not be(perms)
+      perms2 should be(perms1)
+
+      val (loggedout, _) = delete[Boolean](List("session"))
+
+      loggedout should be(true)
+
+    }
+
+    scenario("adding new permission sets") {
+
+      Given("a new person")
+      val person = predefinedPeople.head
+
+      When("he is logged in")
+      val (loggedin, _) = post[Boolean](List("session"), Map("username" -> person.username, "password" -> person.password))
+
+      loggedin should be(true)
+
+      When("he adds new permission sets")
+      val (perms, headers) = get[Map[String,Map[String,Set[String]]]](List("users", person.username, "permissions"))
+
+      headers.get("ETag") should not be('defined)
+
+      val perms1 = perms
+        .updated("custom1", Map("author" -> Set("read")))
+        .updated("custom2", Map("reviewer" -> Set("read")))
+
+      val p = JsonDiff.diff(perms, perms1)
+
+      val (saved, _) = patch[Boolean](List("users", person.username, "permissions"), p, "")
+
+      saved should be(true)
+
+      Then("he can retrieve the newly created permission sets")
+      val (perms2, _) = get[Map[String,Map[String,Set[String]]]](List("users", person.username, "permissions"))
+
+      perms2 should not be(perms)
+      perms2 should be(perms1)
+
+      val (loggedout, _) = delete[Boolean](List("session"))
+
+      loggedout should be(true)
+
+    }
+
+    scenario("deleting custom permission sets") {
+
+      Given("a new person")
+      val person = predefinedPeople.head
+
+      When("he is logged in")
+      val (loggedin, _) = post[Boolean](List("session"), Map("username" -> person.username, "password" -> person.password))
+
+      loggedin should be(true)
+
+      When("he adds new permission sets")
+      val (perms, headers) = get[Map[String,Map[String,Set[String]]]](List("users", person.username, "permissions"))
+
+      headers.get("ETag") should not be('defined)
+
+      val perms1 = perms
+        .updated("custom1", Map("author" -> Set("read")))
+        .updated("custom2", Map("reviewer" -> Set("read")))
+
+      val p = JsonDiff.diff(perms, perms1)
+
+      val (saved, _) = patch[Boolean](List("users", person.username, "permissions"), p, "")
+
+      saved should be(true)
+
+      Then("he can retrieve the newly created permission sets")
+      val (perms2, headers1) = get[Map[String,Map[String,Set[String]]]](List("users", person.username, "permissions"))
+
+      headers1.get("ETag") should be('defined)
+      headers1.get("ETag").value.size should be(1)
+
+      val etag = headers1("ETag").head
+
+      perms2 should not be(perms)
+      perms2 should be(perms1)
+
+      And("he can delete a new permission set")
+      val perms3 = perms2 - "custom2"
+      val p1 = JsonDiff.diff(perms2, perms3)
+
+      val (saved1, _) = patch[Boolean](List("users", person.username, "permissions"), p1, etag)
+
+      saved1 should be(true)
+
+      Then("this permission no longer exists")
+      val (perms4, _) = get[Map[String,Map[String,Set[String]]]](List("users", person.username, "permissions"))
+
+      perms4 should not be(perms)
+      perms4 should not be(perms1)
+      perms4 should not be(perms2)
+      perms4 should be(perms3)
+
+      val (loggedout, _) = delete[Boolean](List("session"))
+
+      loggedout should be(true)
+
+    }
+
+    scenario("deleting overridden default permission sets") {
+
+      Given("a new person")
+      val person = predefinedPeople.head
+
+      When("he is logged in")
+      val (loggedin, _) = post[Boolean](List("session"), Map("username" -> person.username, "password" -> person.password))
+
+      loggedin should be(true)
+
+      When("he overwrites the default public permissions")
+      val (perms, headers) = get[Map[String,Map[String,Set[String]]]](List("users", person.username, "permissions"))
+
+      headers.get("ETag") should not be('defined)
+
+      val perms1 = perms.updated("public", perms("public").updated("anonymous", Set()))
+      val p = JsonDiff.diff(perms, perms1)
+
+      val (saved, _) = patch[Boolean](List("users", person.username, "permissions"), p, "")
+
+      saved should be(true)
+
+      Then("he can retrieve the new permission sets")
+      val (perms2, headers1) = get[Map[String,Map[String,Set[String]]]](List("users", person.username, "permissions"))
+
+      headers1.get("ETag") should be('defined)
+      headers1.get("ETag").value.size should be(1)
+
+      val etag = headers1("ETag").head
+      perms2 should not be(perms)
+      perms2 should be(perms1)
+
+      And("he can then delete the overriding")
+      val perms3 = perms2 - "public"
+
+      val p1 = JsonDiff.diff(perms2, perms3)
+
+      val (saved1, _) = patch[Boolean](List("users", person.username, "permissions"), p1, etag)
+
+      saved1 should be(true)
+
+      Then("this permission no longer exists")
+      val (perms4, _) = get[Map[String,Map[String,Set[String]]]](List("users", person.username, "permissions"))
+
+      perms4 should be(perms)
+      perms4 should not be(perms1)
+      perms4 should not be(perms2)
+      perms4 should not be(perms3)
+
+      val (loggedout, _) = delete[Boolean](List("session"))
+
+      loggedout should be(true)
+
+    }
+
+    scenario("local modifications") {
+
+      Given("a new person")
+      val person = predefinedPeople.head
+
+      When("he is logged in")
+      val (loggedin, _) = post[Boolean](List("session"), Map("username" -> person.username, "password" -> person.password))
+
+      loggedin should be(true)
+
+      When("he adds new permission sets")
+      val (perms, headers) = get[Map[String,Map[String,Set[String]]]](List("users", person.username, "permissions"))
+
+      headers.get("ETag") should not be('defined)
+
+      val perms1 = perms
+        .updated("custom1", Map("author" -> Set("read")))
+        .updated("custom2", Map("reviewer" -> Set("read")))
+
+      val p = JsonDiff.diff(perms, perms1)
+
+      val (saved, _) = patch[Boolean](List("users", person.username, "permissions"), p, "")
+
+      saved should be(true)
+
+      Then("he can retrieve the newly created permission sets")
+      val (perms2, _) = get[Map[String,Map[String,Set[String]]]](List("users", person.username, "permissions"))
+
+      perms2 should not be(perms)
+      perms2 should be(perms1)
+
+      val (loggedout, _) = delete[Boolean](List("session"))
+
+      loggedout should be(true)
+
+      Given("another user")
+      val person1 = predefinedPeople.tail.head
+
+      When("he is logged in")
+      val (loggedin1, _) = post[Boolean](List("session"), Map("username" -> person1.username, "password" -> person1.password))
+
+      loggedin1 should be(true)
+
+      And("retrieves the list of permission sets")
+      val (perms3, headers1) = get[Map[String,Map[String,Set[String]]]](List("users", person.username, "permissions"))
+
+      headers1.get("ETag") should not be('defined)
+
+      Then("he does not see the custom permission sets of other users")
+
+      perms3.keys should not contain("custom1")
+      perms3.keys should not contain("custom2")
+      perms3.keys should contain("public")
+      perms3.keys should contain("private")
+
+
+    }
+
+  }
+
+}

--- a/blue-web/src/main/resources/webapp/i18n/resources-locale_default.js
+++ b/blue-web/src/main/resources/webapp/i18n/resources-locale_default.js
@@ -205,6 +205,11 @@
         "description":"Template"
     },
     {
+        "key":"_Visibility_",
+        "value":"Visibility",
+        "description":"Visibility"
+    },
+    {
         "key":"_Create_",
         "value":"Create",
         "description":"Create"
@@ -1043,7 +1048,11 @@
         "value":"The template of the paper.",
         "description":"tooltip paper page: paper template"
     },
-
+    {
+        "key":"_paper_visbility_tooltip_",
+        "value":"private papers can only be edited by authors, whereas public ones can be edited by anybody (even unregistered people).",
+        "description":"tooltip paper page: private paper"
+    },
 
     {
         "key":"_email_tooltip_",

--- a/blue-web/src/main/resources/webapp/i18n/resources-locale_fr.js
+++ b/blue-web/src/main/resources/webapp/i18n/resources-locale_fr.js
@@ -205,6 +205,11 @@
         "description":"Template"
     },
     {
+        "key":"_Visibility_",
+        "value":"Visibilité",
+        "description":"Visibility"
+    },
+    {
         "key":"_Create_",
         "value":"Créer",
         "description":"Create"
@@ -1037,6 +1042,11 @@
         "key":"_paper_template_tooltip_",
         "value":"Le modèle du document.",
         "description":"tooltip paper page: paper template"
+    },
+    {
+        "key":"_paper_visbility_tooltip_",
+        "value":"Les documents privés ne peuvent être édités que par les auteurs, alors que ceux public peuvent être édités par tous (même les personnes sans compte).",
+        "description":"tooltip paper page: private paper"
     },
 
 

--- a/blue-web/src/main/resources/webapp/js/paper/controllers/NewPaperController.js
+++ b/blue-web/src/main/resources/webapp/js/paper/controllers/NewPaperController.js
@@ -27,6 +27,7 @@ angular.module('bluelatex.Paper.Controllers.NewPaper', [])
       
       var paper = {
         template: "article",
+        visibility: "private",
         paper_title: '',
         paper_name: ''
       };
@@ -34,6 +35,11 @@ angular.module('bluelatex.Paper.Controllers.NewPaper', [])
       $scope.saving=false;
 
       $scope.paper = paper;
+
+      $scope.visibilities = {
+        "public": "public",
+        "private": "private"
+      };
 
       /* Hard-coded for now, but will be dynamically loaded later */
       $scope.templates = {

--- a/blue-web/src/main/resources/webapp/partials/new_paper.html
+++ b/blue-web/src/main/resources/webapp/partials/new_paper.html
@@ -40,6 +40,18 @@
               </select>
             </div>
         </div>
+        <div class="grid">
+            <div class="col c1-3">
+                <label for="visibility" data-i18n="_Visibility_" i18n-Tooltip="_paper_visibility_tooltip_"></label>
+            </div>
+            <div class="col c2-3 form-group"
+              ng-class="{'has-error': newPaperForm.visibility.$invalid}">
+              <select class="form-control" id="visibility" name="visibility"
+                data-i18n-attr="_Visibility_|placeholder" ng-model="paper.visibility"
+                ng-options="key as visibility for (key, visibility) in visibilities">
+              </select>
+            </div>
+        </div>
         <a class="button" href="#/papers" data-i18n="_Cancel_"></a>
         <button type="submit" ng-disabled="!newPaperForm.$valid || saving"  ng-class="{'process': saving}" data-i18n="_Create_"></button>
     </form>

--- a/bnd/lift-json.bnd
+++ b/bnd/lift-json.bnd
@@ -1,6 +1,0 @@
-Bundle-Name: Liftweb JSON library
-Bundle-SymbolicName: net.liftweb.json
-Bundle-Version: 2.6.0.RC1
-Export-Package: *
-
-Import-Package: *

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -68,23 +68,23 @@ class BlueBuild extends Build with Pack with Server with Distrib with Tests {
   lazy val commonDeps = Seq(
     "org.gnieh" %% "tiscaf" % "0.9",
     "net.tanesha.recaptcha4j" % "recaptcha4j" % "0.0.7",
-    "org.apache.pdfbox" % "pdfbox" % "1.8.4" exclude("commons-logging", "commons-logging"),
-    "commons-beanutils" % "commons-beanutils" % "1.8.3" exclude("commons-logging", "commons-logging"),
+    "org.apache.pdfbox" % "pdfbox" % "1.8.8" exclude("commons-logging", "commons-logging"),
+    "commons-beanutils" % "commons-beanutils" % "1.9.2" exclude("commons-logging", "commons-logging"),
     "commons-collections" % "commons-collections" % "3.2.1",
-    "com.typesafe.akka" %% "akka-osgi" % "2.3.1",
+    "com.typesafe.akka" %% "akka-osgi" % "2.3.9",
     "org.gnieh" %% "tekstlib" % "0.1.0-SNAPSHOT",
-    "org.gnieh" %% "sohva-client" % "1.0.0",
-    "org.gnieh" %% "sohva-entities" % "1.0.0",
-    "org.gnieh" %% "diffson" % "0.3",
+    "org.gnieh" %% "sohva-client" % "1.1.2-SNAPSHOT",
+    "org.gnieh" %% "sohva-entities" % "1.1.2-SNAPSHOT",
+    "org.gnieh" %% "diffson" % "0.3.1",
     "javax.mail" % "mail" % "1.4.7",
-    "ch.qos.logback" % "logback-classic" % "1.0.13",
-    "org.slf4j" % "jcl-over-slf4j" % "1.7.5",
-    "com.jsuereth" %% "scala-arm" % "1.3",
-    "org.osgi" % "org.osgi.core" % "4.3.0" % "provided",
-    "org.osgi" % "org.osgi.compendium" % "4.3.0" % "provided",
-    "com.typesafe" % "config" % "1.0.2",
-    "org.scalatest" %% "scalatest" % "2.2.0" % "test",
-    "com.typesafe.akka" %% "akka-testkit" % "2.3.1" % "test"
+    "ch.qos.logback" % "logback-classic" % "1.1.2",
+    "org.slf4j" % "jcl-over-slf4j" % "1.7.10",
+    "com.jsuereth" %% "scala-arm" % "1.4",
+    "org.osgi" % "org.osgi.core" % "4.3.1" % "provided",
+    "org.osgi" % "org.osgi.compendium" % "4.3.1" % "provided",
+    "com.typesafe" % "config" % "1.2.1",
+    "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+    "com.typesafe.akka" %% "akka-testkit" % "2.3.9" % "test"
   )
 
   lazy val blueMobwrite =


### PR DESCRIPTION
For the moment, it is mainly opened to see if nothing breaks.

Basically, permissions are check in a more fine-grained way so that the role can have different permission on different papers.
There are two (configurable) permission profiles:
 - private, which is the behavior we had before
 - public, which gives all the permission to everybody, even people that are not registered into \BlueLaTeX