### PR TITLE
[fix #188] heisenbug in synchronization

### DIFF
--- a/blue-sync/src/main/scala/gnieh/blue/sync/impl/SyncActor.scala
+++ b/blue-sync/src/main/scala/gnieh/blue/sync/impl/SyncActor.scala
@@ -215,7 +215,7 @@ class SyncActor(
       view.deltaOk = false
     } else if (revision == view.serverShadowRevision) {
       // The version number matches the shadow, proceed.
-      view.deltaOk == true
+      view.deltaOk = true
     }
 
     action match {


### PR DESCRIPTION
After a conflict the server always sents a RAW response because
the server didn't change the status of the paper and considered
that the conflict was not managed.

The bug was "deltaOk == true" instead of "deltaOk = true".