### PR TITLE
[fix #201] Start compilation removes "Error" and "Warning"

### DIFF
--- a/blue-web/src/main/resources/webapp/js/paper/controllers/LatexPaperController.js
+++ b/blue-web/src/main/resources/webapp/js/paper/controllers/LatexPaperController.js
@@ -616,7 +616,6 @@ angular.module('bluelatex.Paper.Controllers.LatexPaper', [
           deferred.reject("compile in progress");
           return deferred.promise;
         }
-
         compileActive = true;
         PaperService.subscribePaperCompiler($scope.paperId).then(function (data) {
           compileActive = false;
@@ -760,6 +759,7 @@ angular.module('bluelatex.Paper.Controllers.LatexPaper', [
                 $scope.compileInProgress = true;
                 $scope.$$phase || $scope.$apply();
                 MobWriteService.synchronize().then(function() {
+                  $scope.logs = [];
                   $scope.compile().finally(function() {
                     $scope.compileInProgress = false;
                     $scope.$$phase || $scope.$apply();


### PR DESCRIPTION
When the user asks for the compilation (ctrl+s) the list of errors and warnings is reset.