### PR TITLE
[fix #214] Ignore messages from unknown peers

### DIFF
--- a/blue-sync/src/main/scala/gnieh/blue/sync/impl/SyncActor.scala
+++ b/blue-sync/src/main/scala/gnieh/blue/sync/impl/SyncActor.scala
@@ -271,12 +271,16 @@ class SyncActor(
   def processMessage(syncContext: SyncContext, peer: PeerId, message: Message): SyncActionResult = {
     logDebug(s"Process message: $message")
 
-    val updatedMessages = for {
-      p <- syncContext.messages.keys
-      if (p != peer)
-    } yield (p, message :: syncContext.messages(p))
+    if(syncContext.messages.contains(peer)) {
+      val updatedMessages = for {
+        p <- syncContext.messages.keys
+        if p != peer
+      } yield (p, message :: syncContext.messages(p))
 
-    SyncActionResult(syncContext.updateMessages(updatedMessages.toMap + (peer -> syncContext.messages(peer))), Nil)
+      SyncActionResult(syncContext.updateMessages(updatedMessages.toMap + (peer -> syncContext.messages(peer))), Nil)
+    } else {
+      SyncActionResult(syncContext, Nil)
+    }
   }
 
   def retrieveMessages(syncContext: SyncContext, peer: PeerId, paperId: PaperId): SyncActionResult =


### PR DESCRIPTION
If a peer sends a message to broadcast but is still unknown to the
server, his message is simply ignored.
Before the first synchronization, a peer cannot send his position but
I'd say it is safer this way anyway and is not much of a problem.

In any way, the server should not throw any exception in this case.