### PR TITLE
changes default configuration option registration-confirmation

### DIFF
--- a/blue-common/src/main/resources/application.conf
+++ b/blue-common/src/main/resources/application.conf
@@ -27,7 +27,7 @@ blue {
   #    then receives an information email with summary of registration
   #   `no-email` the user chooses his password upon registration and receives no
   #   email
-  registration-confirmation = "email-confirmation"
+  registration-confirmation = "email-summary"
 
   # the base directory where the working data are saved
   data = "/var/lib/blue"

--- a/blue-dist/src/configuration/org.gnieh.blue.common/application.conf
+++ b/blue-dist/src/configuration/org.gnieh.blue.common/application.conf
@@ -10,6 +10,7 @@ blue {
 
   data = $data_dir
 
+  registration-confirmation = "email-summary"
 }
 
 couch {


### PR DESCRIPTION
To facilitate the setup of the project for newcomers, no email confirmation is used by default