### PR TITLE
[fix #244] Disable undo after paper load

### DIFF
--- a/blue-web/src/main/resources/webapp/js/paper/controllers/LatexPaperController.js
+++ b/blue-web/src/main/resources/webapp/js/paper/controllers/LatexPaperController.js
@@ -164,6 +164,7 @@ angular.module('bluelatex.Paper.Controllers.LatexPaper', [
         AceMobWriteClient.message({ type: 'cursor', 'user': $rootScope.loggedUser.name });
         return MobWriteService.share({paper_id: $scope.paperId,file:$scope.currentFile.title}).then(function (){
           displayAnnotation();
+          AceService.getSession().setValue(AceService.getContent(), -1);
           $scope.toc = LatexService.parseTOC(AceService.getContent());
           AceService.getEditor().focus();
           $scope.goToLine(0, 0);


### PR DESCRIPTION
Calls the method editor.session.setValue() after the paper load.
This method reset the undomanager.