### PR TITLE
[fix #258] Makes the index after the compilation

### DIFF
--- a/blue-compile/src/main/scala/gnieh/blue/compile/Compiler.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/Compiler.scala
@@ -53,5 +53,10 @@ trait Compiler {
    */
   def bibtex(paperId: String, settings: CompilerSettings)(implicit timeout: Timeout): Try[Boolean]
 
+  /** Do the makeindex task for a paper, given the base directory
+   *  containing the paper files.
+   */
+  def makeindex(paperId: String, settings: CompilerSettings)(implicit timeout: Timeout): Try[Boolean]
+
 }
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/SystemCompiler.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/SystemCompiler.scala
@@ -67,6 +67,10 @@ abstract class SystemCompiler(system: ActorSystem, config: Config, texmfcnf: Fil
     exec(s"bibtex main.aux", configuration.buildDir(paperId))
   }
 
+  def makeindex(paperId: String, settings: CompilerSettings)(implicit timeout: Timeout): Try[Boolean] = {
+    exec(s"makeindex main.idx", configuration.buildDir(paperId))
+  }
+
   protected def buildDir(paperId: String) = configuration.buildDir(paperId).getCanonicalPath
   protected def paperFile(paperId: String) = configuration.paperFile(paperId).getName
 

--- a/blue-compile/src/main/scala/gnieh/blue/compile/impl/ExplicitCompilationActor.scala
+++ b/blue-compile/src/main/scala/gnieh/blue/compile/impl/ExplicitCompilationActor.scala
@@ -121,6 +121,7 @@ class ExplicitCompilationActor(
           res <- compiler.compile(paperId, settings)
           // we run bibtex on it if the compilation succeeded
           _ <- compiler.bibtex(paperId, settings)
+          _ <- compiler.makeindex(paperId, settings)
         } yield {
           // clean the generated png files when compilation succeeded
           for(file <- paperConfig.buildDir(paperId).filter(_.extension == ".png"))


### PR DESCRIPTION
Call `makeindex build/main.idx` when the compilation succeed.

I have no idea how to test this PR, sorry.